### PR TITLE
hal: nuvoton: add hal layer drivers for nuvoton npcx series

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,3 +4,13 @@
 # Author: Saravanan Sekar <saravanan@linumiz.com>
 
 add_subdirectory_ifdef(CONFIG_SOC_SERIES_M48X m48x)
+
+add_subdirectory_ifdef(CONFIG_HAS_NPCX_HAL npcx)
+
+if(CONFIG_CLOCK_NPCX_OSC_CYCLES_PER_SEC)
+  zephyr_compile_definitions( -DOSC_CLK_VAL=${CONFIG_CLOCK_NPCX_OSC_CYCLES_PER_SEC} )
+endif()
+
+if(CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC)
+  zephyr_compile_definitions( -DCORE_CLK_VAL=${CONFIG_SYS_CLOCK_HW_CYCLES_PER_SEC} )
+endif()

--- a/npcx/CMakeLists.txt
+++ b/npcx/CMakeLists.txt
@@ -1,0 +1,11 @@
+#
+# Copyright (c) 2020 Nuvoton Technology Corporation.
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+
+zephyr_include_directories_ifdef(CONFIG_SOC_FAMILY_NPCX .)
+
+zephyr_include_directories_ifdef(CONFIG_SOC_FAMILY_NPCX common)
+zephyr_include_directories_ifdef(CONFIG_SOC_FAMILY_NPCX modules)
+zephyr_include_directories_ifdef(CONFIG_SOC_SERIES_NPCX7 npcx7)

--- a/npcx/LICENSE
+++ b/npcx/LICENSE
@@ -1,0 +1,27 @@
+// Copyright 2010 The Chromium OS Authors. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions are
+// met:
+//
+//    * Redistributions of source code must retain the above copyright
+// notice, this list of conditions and the following disclaimer.
+//    * Redistributions in binary form must reproduce the above
+// copyright notice, this list of conditions and the following disclaimer
+// in the documentation and/or other materials provided with the
+// distribution.
+//    * Neither the name of Google Inc. nor the names of its
+// contributors may be used to endorse or promote products derived from
+// this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+// "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+// LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+// A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+// OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+// SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+// DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+// THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/npcx/common/reg_access.h
+++ b/npcx/common/reg_access.h
@@ -1,0 +1,50 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NUVOTON_NPCX_REG_ACCESS_H
+#define _NUVOTON_NPCX_REG_ACCESS_H
+
+/******************************************************************************/
+/*
+ * Register Access Macro Functions
+ */
+/* Reg access functions */
+#define REG32_ADDR(addr) ((volatile uint32_t *)(addr))
+#define REG16_ADDR(addr) ((volatile uint16_t *)(addr))
+#define REG8_ADDR(addr)  ((volatile uint8_t  *)(addr))
+
+#define REG32(addr) (*REG32_ADDR(addr))
+#define REG16(addr) (*REG16_ADDR(addr))
+#define REG8(addr)  (*REG8_ADDR(addr))
+
+/* Reg bit functions */
+#define BIT(n)                      (1UL << (n))
+#define SET_BIT(reg, bit)           ((reg) |= (0x1 << (bit)))
+#define CLEAR_BIT(reg, bit)         ((reg) &= (~(0x1 << (bit))))
+#define IS_BIT_SET(reg, bit)        ((reg >> bit) & (0x1))
+#define UPDATE_BIT(reg, bit, cond)  {	if (cond) \
+						SET_BIT(reg, bit); \
+					else \
+						CLEAR_BIT(reg, bit); }
+
+/* Reg field functions */
+#define GET_POS_FIELD(pos, size)    pos
+#define GET_SIZE_FIELD(pos, size)   size
+#define FIELD_POS(field)            GET_POS_##field
+#define FIELD_SIZE(field)           GET_SIZE_##field
+
+/* Read field functions */
+#define GET_FIELD(reg, field) \
+	_GET_FIELD_(reg, FIELD_POS(field), FIELD_SIZE(field))
+#define _GET_FIELD_(reg, f_pos, f_size) (((reg)>>(f_pos)) & ((1<<(f_size))-1))
+
+/* Write field functions */
+#define SET_FIELD(reg, field, value) \
+	_SET_FIELD_(reg, FIELD_POS(field), FIELD_SIZE(field), value)
+#define _SET_FIELD_(reg, f_pos, f_size, value) \
+	((reg) = ((reg) & (~(((1 << (f_size))-1) << (f_pos)))) \
+			| ((value) << (f_pos)))
+
+#endif /* _NUVOTON_NPCX_REG_ACCESS_H */

--- a/npcx/common/reg_type.h
+++ b/npcx/common/reg_type.h
@@ -1,0 +1,54 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NUVOTON_NPCX_REG_TYPE_H
+#define _NUVOTON_NPCX_REG_TYPE_H
+
+#include <stdint.h>
+
+/******************************************************************************/
+/*
+ * Register Type Definitions
+ */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* ADC device instance */
+typedef  uint8_t *adc_inst_t;
+/* CDCG device instance */
+typedef  uint8_t *cdcg_inst_t;
+/* ESPI device instance */
+typedef  uint8_t *espi_inst_t;
+/* GPIO device instance */
+typedef  uint8_t *gpio_inst_t;
+/* ITIM device instance */
+typedef  uint8_t *itim_inst_t;
+/* MIWU device instance */
+typedef  uint8_t *miwu_inst_t;
+/* PMC device instance */
+typedef  uint8_t *pmc_inst_t;
+/* PWM device instance */
+typedef  uint8_t *pwm_inst_t;
+/* SCFG device instance */
+typedef  uint8_t *scfg_inst_t;
+/* SMB device instance */
+typedef  uint8_t *smb_inst_t;
+/* TWD device instance */
+typedef  uint8_t *twd_inst_t;
+/* UART device instance */
+typedef  uint8_t *uart_inst_t;
+/* WDT device instance */
+typedef  uint8_t *wdt_inst_t;
+
+
+#ifdef __cplusplus
+}
+#endif
+
+
+
+#endif /* _NUVOTON_NPCX_REG_TYPE_H */

--- a/npcx/modules/adc.h
+++ b/npcx/modules/adc.h
@@ -1,0 +1,84 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_ADC_H
+#define _NPCX_ADC_H
+
+/******************************************************************************/
+/* ADC register definitions */
+#define NPCX_ADCSTS(base_addr)               REG16((base_addr) + 0x000)
+#define NPCX_ADCCNF(base_addr)               REG16((base_addr) + 0x002)
+#define NPCX_ATCTL(base_addr)                REG16((base_addr) + 0x004)
+#define NPCX_ASCADD(base_addr)               REG16((base_addr) + 0x006)
+#define NPCX_ADCCS(base_addr)                REG16((base_addr) + 0x008)
+#define NPCX_CHNDAT(base_addr, ch)           REG16((base_addr) + 0x040 + (2L*(ch)))
+#define NPCX_ADCCNF2(base_addr)              REG16((base_addr) + 0x020)
+#define NPCX_GENDLY(base_addr)               REG16((base_addr) + 0x022)
+#define NPCX_MEAST(base_addr)                REG16((base_addr) + 0x026)
+
+/* ADC register fields */
+#define NPCX_ATCTL_SCLKDIV_FIELD              FIELD(0, 6)
+#define NPCX_ATCTL_DLY_FIELD                  FIELD(8, 3)
+#define NPCX_ASCADD_SADDR_FIELD               FIELD(0, 5)
+#define NPCX_ADCSTS_EOCEV                     0
+#define NPCX_ADCSTS_EOCCEV                    1
+#define NPCX_ADCCNF_ADCMD_FIELD               FIELD(1, 2)
+#define NPCX_ADCCNF_ADCRPTC                   3
+#define NPCX_ADCCNF_INTECEN                   6
+#define NPCX_ADCCNF_START                     4
+#define NPCX_ADCCNF_ADCEN                     0
+#define NPCX_ADCCNF_STOP                      11
+#define NPCX_CHNDAT_CHDAT_FIELD               FIELD(0, 10)
+#define NPCX_CHNDAT_NEW                       15
+#define NPCX_THRCTL_THEN                      15
+#define NPCX_THRCTL_L_H                       14
+#define NPCX_THRCTL_CHNSEL                    FIELD(10, 4)
+#define NPCX_THRCTL_THRVAL                    FIELD(0, 10)
+#define NPCX_THRCTS_ADC_WKEN                  15
+#define NPCX_THRCTS_THR3_IEN                  10
+#define NPCX_THRCTS_THR2_IEN                  9
+#define NPCX_THRCTS_THR1_IEN                  8
+#define NPCX_THRCTS_ADC_EVENT                 7
+#define NPCX_THRCTS_THR3_STS                  2
+#define NPCX_THRCTS_THR2_STS                  1
+#define NPCX_THRCTS_THR1_STS                  0
+#define NPCX_THR_DCTL_THRD_EN                 15
+#define NPCX_THR_DCTL_THR_DVAL                FIELD(0, 10)
+
+/******************************************************************************/
+/* ADC macro functions */
+#define NPCX_ADC_CLK                          2000000 /* Operate in 2MHz */
+#define NPCX_ADC_REGULAR_DLY                  0x02 /* 010 */
+/* Maximum time we allow for an ADC conversion */
+#define ADC_TIMEOUT_US                        USEC_PER_SEC
+#define ADC_REGULAR_ADCCNF2                   0x8B07
+#define ADC_REGULAR_GENDLY                    0x0100
+#define ADC_REGULAR_MEAST                     0x0001
+
+/******************************************************************************/
+/* ADC enumeration */
+
+/* ADC input channel select */
+enum npcx_adc_input_channel {
+	NPCX_ADC_CH0 = 0,
+	NPCX_ADC_CH1,
+	NPCX_ADC_CH2,
+	NPCX_ADC_CH3,
+	NPCX_ADC_CH4,
+	NPCX_ADC_CH5,
+	NPCX_ADC_CH6,
+	NPCX_ADC_CH7,
+	NPCX_ADC_CH8,
+	NPCX_ADC_CH9,
+	NPCX_ADC_CH_COUNT
+};
+
+/* ADC conversion mode */
+enum npcx_adc_conversion_mode {
+	ADC_CHN_CONVERSION_MODE   = 0,
+	ADC_SCAN_CONVERSION_MODE  = 1
+};
+
+#endif /* _NPCX_ADC_H */

--- a/npcx/modules/clock.h
+++ b/npcx/modules/clock.h
@@ -1,0 +1,209 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_CLOCK_H
+#define _NPCX_CLOCK_H
+
+/******************************************************************************/
+/* Clock controller register definitions */
+
+/* High Frequency Clock Generator (HFCG) registers */
+#define NPCX_HFCGCTRL(base_addr)              REG8((base_addr) + 0x000)
+#define NPCX_HFCGML(base_addr)                REG8((base_addr) + 0x002)
+#define NPCX_HFCGMH(base_addr)                REG8((base_addr) + 0x004)
+#define NPCX_HFCGN(base_addr)                 REG8((base_addr) + 0x006)
+#define NPCX_HFCGP(base_addr)                 REG8((base_addr) + 0x008)
+#define NPCX_HFCBCD(base_addr)                REG8((base_addr) + 0x010)
+#define NPCX_HFCBCD1(base_addr)               REG8((base_addr) + 0x012)
+#define NPCX_HFCBCD2(base_addr)               REG8((base_addr) + 0x014)
+
+/* HFCG register fields */
+#define NPCX_HFCGCTRL_LOAD                    0
+#define NPCX_HFCGCTRL_LOCK                    2
+#define NPCX_HFCGCTRL_CLK_CHNG                7
+
+/******************************************************************************/
+/* Low Frequency Clock Generator (LFCG) registers */
+#define NPCX_LFCGCTL(base_addr)               REG8((base_addr) + 0x100)
+#define NPCX_HFRDI(base_addr)                REG16((base_addr) + 0x102)
+#define NPCX_HFRDF(base_addr)                REG16((base_addr) + 0x104)
+#define NPCX_FRCDIV(base_addr)               REG16((base_addr) + 0x106)
+#define NPCX_DIVCOR1(base_addr)              REG16((base_addr) + 0x108)
+#define NPCX_DIVCOR2(base_addr)              REG16((base_addr) + 0x10A)
+#define NPCX_LFCGCTL2(base_addr)              REG8((base_addr) + 0x114)
+
+/* LFCG register fields */
+#define NPCX_LFCGCTL_XTCLK_VAL                7
+#define NPCX_LFCGCTL2_XT_OSC_SL_EN            6
+
+/******************************************************************************/
+/* Power Management Controller (PMC) Registers */
+#define NPCX_PMCSR(base_addr)                 REG8((base_addr) + 0x000)
+#define NPCX_ENIDL_CTL(base_addr)             REG8((base_addr) + 0x003)
+#define NPCX_DISIDL_CTL(base_addr)            REG8((base_addr) + 0x004)
+#define NPCX_DISIDL_CTL1(base_addr)           REG8((base_addr) + 0x005)
+#define NPCX_PWDWN_CTL_ADDR(base_addr, n)     (((n) < 6) ? \
+			                       ((base_addr) + 0x008 + (n)) : \
+			                       ((base_addr) + 0x024))
+#define NPCX_PWDWN_CTL(base_addr, n)          REG8(NPCX_PWDWN_CTL_ADDR \
+		                               (base_addr, n))
+#define NPCX_RAM_PD(base_addr, n)             REG8((base_addr) + 0x020 + n)
+
+/* PMC register fields */
+#define NPCX_PMCSR_DI_INSTW                   0
+#define NPCX_PMCSR_DHF                        1
+#define NPCX_PMCSR_IDLE                       2
+#define NPCX_PMCSR_NWBI                       3
+#define NPCX_PMCSR_OHFC                       6
+#define NPCX_PMCSR_OLFC                       7
+#define NPCX_DISIDL_CTL_RAM_DID               5
+#define NPCX_ENIDL_CTL_ADC_LFSL               7
+#define NPCX_ENIDL_CTL_LP_WK_CTL              6
+#define NPCX_ENIDL_CTL_PECI_ENI               2
+#define NPCX_ENIDL_CTL_ADC_ACC_DIS            1
+#define NPCX_PWDWN_CTL1_KBS_PD                0
+#define NPCX_PWDWN_CTL1_SDP_PD                1
+#define NPCX_PWDWN_CTL1_FIU_PD                2
+#define NPCX_PWDWN_CTL1_PS2_PD                3
+#define NPCX_PWDWN_CTL1_UART_PD               4
+#define NPCX_PWDWN_CTL1_MFT1_PD               5
+#define NPCX_PWDWN_CTL1_MFT2_PD               6
+#define NPCX_PWDWN_CTL1_MFT3_PD               7
+#define NPCX_PWDWN_CTL2_PWM0_PD               0
+#define NPCX_PWDWN_CTL2_PWM1_PD               1
+#define NPCX_PWDWN_CTL2_PWM2_PD               2
+#define NPCX_PWDWN_CTL2_PWM3_PD               3
+#define NPCX_PWDWN_CTL2_PWM4_PD               4
+#define NPCX_PWDWN_CTL2_PWM5_PD               5
+#define NPCX_PWDWN_CTL2_PWM6_PD               6
+#define NPCX_PWDWN_CTL2_PWM7_PD               7
+#define NPCX_PWDWN_CTL3_SMB0_PD               0
+#define NPCX_PWDWN_CTL3_SMB1_PD               1
+#define NPCX_PWDWN_CTL3_SMB2_PD               2
+#define NPCX_PWDWN_CTL3_SMB3_PD               3
+#define NPCX_PWDWN_CTL3_SMB4_PD               4
+#define NPCX_PWDWN_CTL3_GMDA_PD               7
+#define NPCX_PWDWN_CTL4_ITIM1_PD              0
+#define NPCX_PWDWN_CTL4_ITIM2_PD              1
+#define NPCX_PWDWN_CTL4_ITIM3_PD              2
+#define NPCX_PWDWN_CTL4_ADC_PD                4
+#define NPCX_PWDWN_CTL4_PECI_PD               5
+#define NPCX_PWDWN_CTL4_PWM6_PD               6
+#define NPCX_PWDWN_CTL4_SPIP_PD               7
+#define NPCX_PWDWN_CTL5_SHI_PD                1
+#define NPCX_PWDWN_CTL5_MRFSH_DIS             2
+#define NPCX_PWDWN_CTL5_C2HACC_PD             3
+#define NPCX_PWDWN_CTL5_SHM_REG_PD            4
+#define NPCX_PWDWN_CTL5_SHM_PD                5
+#define NPCX_PWDWN_CTL5_DP80_PD               6
+#define NPCX_PWDWN_CTL5_MSWC_PD               7
+#define NPCX_PWDWN_CTL6_ITIM4_PD              0
+#define NPCX_PWDWN_CTL6_ITIM5_PD              1
+#define NPCX_PWDWN_CTL6_ITIM6_PD              2
+#define NPCX_PWDWN_CTL6_ESPI_PD               7
+#define NPCX_PWDWN_CTL7_SMB5_PD               0
+#define NPCX_PWDWN_CTL7_SMB6_PD               1
+#define NPCX_PWDWN_CTL7_SMB7_PD               2
+#define NPCX_PWDWN_CTL7_ITIM64_PD             5
+#define NPCX_PWDWN_CTL7_UART2_PD              6
+#define NPCX_PWDWN_CTL7_WOV_PD                7
+
+/******************************************************************************/
+/* Clock controller macro functions */
+/*
+ * NPCX7 and later series clock tree:
+ * (Please refer Figure 58. for more information.)
+ *
+ * Suggestion:
+ * - OSC_CLK >= 80MHz, XF_RANGE should be 1, else 0.
+ * - CORE_CLK > 66MHz, AHB6DIV should be 1, else 0.
+ * - CORE_CLK > 50MHz, FIUDIV should be 1, else 0.
+ */
+
+/* Target OSC_CLK freq */
+#define OSC_CLK   OSC_CLK_VAL
+/* Core domain clock */
+#define CORE_CLK  CORE_CLK_VAL
+/* Low Frequency clock */
+#define LFCLK     32768
+/* Core clock prescaler */
+#define FPRED ((OSC_CLK / CORE_CLK) - 1 )
+
+/* FMUL clock */
+#if (OSC_CLK >= 80000000)
+#define FMCLK (OSC_CLK / 2) /* FMUL clock = OSC_CLK/2 if OSC_CLK >= 80MHz */
+#else
+#define FMCLK OSC_CLK /* FMUL clock = OSC_CLK */
+#endif
+
+/* APBs source clock */
+#define APBSRC_CLK OSC_CLK
+/* APB1 clock divider, default value (APB1 clock = OSC_CLK/6) */
+#define APB1DIV (CONFIG_CLOCK_NPCX_APB1_PRESCALER - 1)
+/* APB2 clock divider, default value (APB2 clock = OSC_CLK/6) */
+#define APB2DIV (CONFIG_CLOCK_NPCX_APB2_PRESCALER - 1)
+/* APB3 clock divider, default value (APB3 clock = OSC_CLK/6) */
+#define APB3DIV (CONFIG_CLOCK_NPCX_APB3_PRESCALER - 1)
+
+/* AHB6 clock */
+#if (CORE_CLK > 66000000)
+#define AHB6DIV 1 /* AHB6_CLK = CORE_CLK/2 if CORE_CLK > 66MHz */
+#else
+#define AHB6DIV 0 /* AHB6_CLK = CORE_CLK */
+#endif
+/* FIU clock divider */
+#if (CORE_CLK > 50000000)
+#define FIUDIV 1 /* FIU_CLK = CORE_CLK/2 */
+#else
+#define FIUDIV 0 /* FIU_CLK = CORE_CLK */
+#endif
+
+/* Get APB clock freq */
+#define NPCX_APB_CLOCK(no) (APBSRC_CLK / (APB##no##DIV + 1))
+
+/*
+ * Frequency multiplier M/N value definitions according to the requested
+ * OSC_CLK (Unit:Hz).
+ */
+#if (OSC_CLK > 80000000)
+#define HFCGN    0x82 /* Set XF_RANGE as 1 if OSC_CLK >= 80MHz */
+#else
+#define HFCGN    0x02
+#endif
+#if   (OSC_CLK == 100000000)
+#define HFCGMH   0x0B
+#define HFCGML   0xEC
+#elif (OSC_CLK == 90000000)
+#define HFCGMH   0x0A
+#define HFCGML   0xBA
+#elif (OSC_CLK == 80000000)
+#define HFCGMH   0x09
+#define HFCGML   0x89
+#elif (OSC_CLK == 66000000)
+#define HFCGMH   0x0F
+#define HFCGML   0xBC
+#elif (OSC_CLK == 50000000)
+#define HFCGMH   0x0B
+#define HFCGML   0xEC
+#elif (OSC_CLK == 48000000)
+#define HFCGMH   0x0B
+#define HFCGML   0x72
+#elif (OSC_CLK == 40000000)
+#define HFCGMH   0x09
+#define HFCGML   0x89
+#elif (OSC_CLK == 33000000)
+#define HFCGMH   0x07
+#define HFCGML   0xDE
+#elif (OSC_CLK == 30000000)
+#define HFCGMH   0x07
+#define HFCGML   0x27
+#elif (OSC_CLK == 26000000)
+#define HFCGMH   0x06
+#define HFCGML   0x33
+#else
+#error "Unsupported OSC_CLK Frequency"
+#endif
+
+#endif /* _NPCX_CLOCK_H */

--- a/npcx/modules/espi.h
+++ b/npcx/modules/espi.h
@@ -1,0 +1,249 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_ESPI_H
+#define _NPCX_ESPI_H
+
+/******************************************************************************/
+/* ESPI register definitions */
+#define NPCX_ESPIID(base_addr)           REG32((base_addr) + 0X00)
+#define NPCX_ESPICFG(base_addr)          REG32((base_addr) + 0X04)
+#define NPCX_ESPISTS(base_addr)          REG32((base_addr) + 0X08)
+#define NPCX_ESPIIE(base_addr)           REG32((base_addr) + 0X0C)
+#define NPCX_ESPIWE(base_addr)           REG32((base_addr) + 0X10)
+#define NPCX_VWREGIDX(base_addr)         REG32((base_addr) + 0X14)
+#define NPCX_VWREGDATA(base_addr)        REG32((base_addr) + 0X18)
+#define NPCX_OOBCTL(base_addr)           REG32((base_addr) + 0X24)
+#define NPCX_FLASHRXRDHEAD(base_addr)    REG32((base_addr) + 0X28)
+#define NPCX_FLASHTXWRHEAD(base_addr)    REG32((base_addr) + 0X2C)
+#define NPCX_FLASHCFG(base_addr)         REG32((base_addr) + 0X34)
+#define NPCX_FLASHCTL(base_addr)         REG32((base_addr) + 0X38)
+#define NPCX_ESPIERR(base_addr)          REG32((base_addr) + 0X3C)
+
+/* eSPI Virtual Wire channel registers */
+#define NPCX_VWEVSM(ch)                  REG32((base_addr) + 0x100 + (4*(ch)))
+#define NPCX_VWEVMS(ch)                  REG32((base_addr) + 0x140 + (4*(ch)))
+#define NPCX_VWCTL                       REG32((base_addr) + 0x2FC)
+
+/* eSPI register fields */
+#define NPCX_ESPICFG_PCHANEN             0
+#define NPCX_ESPICFG_VWCHANEN            1
+#define NPCX_ESPICFG_OOBCHANEN           2
+#define NPCX_ESPICFG_FLASHCHANEN         3
+#define NPCX_ESPICFG_IOMODE_FIELD        FIELD(8, 9)
+#define NPCX_ESPICFG_MAXFREQ_FIELD       FIELD(10, 12)
+#define NPCX_ESPICFG_PCCHN_SUPP          24
+#define NPCX_ESPICFG_VWCHN_SUPP          25
+#define NPCX_ESPICFG_OOBCHN_SUPP         26
+#define NPCX_ESPICFG_FLASHCHN_SUPP       27
+#define NPCX_ESPIIE_IBRSTIE              0
+#define NPCX_ESPIIE_CFGUPDIE             1
+#define NPCX_ESPIIE_BERRIE               2
+#define NPCX_ESPIIE_OOBRXIE              3
+#define NPCX_ESPIIE_FLASHRXIE            4
+#define NPCX_ESPIIE_SFLASHRDIE           5
+#define NPCX_ESPIIE_PERACCIE             6
+#define NPCX_ESPIIE_DFRDIE               7
+#define NPCX_ESPIIE_VWUPDIE              8
+#define NPCX_ESPIIE_ESPIRSTIE            9
+#define NPCX_ESPIIE_PLTRSTIE             10
+#define NPCX_ESPIIE_AMERRIE              15
+#define NPCX_ESPIIE_AMDONEIE             16
+#define NPCX_ESPIIE_BMTXDONEIE           19
+#define NPCX_ESPIIE_PBMRXIE              20
+#define NPCX_ESPIIE_PMSGRXIE             21
+#define NPCX_ESPIIE_BMBURSTERRIE         22
+#define NPCX_ESPIIE_BMBURSTDONEIE        23
+#define NPCX_ESPIWE_IBRSTWE              0
+#define NPCX_ESPIWE_CFGUPDWE             1
+#define NPCX_ESPIWE_BERRWE               2
+#define NPCX_ESPIWE_OOBRXWE              3
+#define NPCX_ESPIWE_FLASHRXWE            4
+#define NPCX_ESPIWE_PERACCWE             6
+#define NPCX_ESPIWE_DFRDWE               7
+#define NPCX_ESPIWE_VWUPDWE              8
+#define NPCX_ESPIWE_ESPIRSTWE            9
+#define NPCX_ESPIWE_PBMRXWE              20
+#define NPCX_ESPIWE_PMSGRXWE             21
+#define NPCX_ESPISTS_IBRST               0
+#define NPCX_ESPISTS_CFGUPD              1
+#define NPCX_ESPISTS_BERR                2
+#define NPCX_ESPISTS_OOBRX               3
+#define NPCX_ESPISTS_FLASHRX             4
+#define NPCX_ESPISTS_SFLASHRD            5
+#define NPCX_ESPISTS_PERACC              6
+#define NPCX_ESPISTS_DFRD                7
+#define NPCX_ESPISTS_VWUPD               8
+#define NPCX_ESPISTS_ESPIRST             9
+#define NPCX_ESPISTS_PLTRST              10
+#define NPCX_ESPISTS_AMERR               15
+#define NPCX_ESPISTS_AMDONE              16
+#define NPCX_ESPISTS_VWUPDW              17
+#define NPCX_ESPISTS_BMTXDONE            19
+#define NPCX_ESPISTS_PBMRX               20
+#define NPCX_ESPISTS_PMSGRX              21
+#define NPCX_ESPISTS_BMBURSTERR          22
+#define NPCX_ESPISTS_BMBURSTDONE         23
+#define NPCX_ESPISTS_ESPIRST_LVL         24
+/* eSPI Virtual Wire channel register fields */
+#define NPCX_VWEVSM_WIRE                 FIELD(0, 4)
+#define NPCX_VWEVMS_WIRE                 FIELD(0, 4)
+#define NPCX_VWEVSM_VALID                FIELD(4, 4)
+#define NPCX_VWEVMS_VALID                FIELD(4, 4)
+
+/******************************************************************************/
+/* ESPI macro functions */
+/* Macro functions for eSPI CFG & IE */
+#define IS_SLAVE_CHAN_ENABLE(ch)         IS_BIT_SET(NPCX_ESPICFG, ch)
+#define IS_HOST_CHAN_EN(ch)              IS_BIT_SET(NPCX_ESPICFG, (ch+4))
+#define ENABLE_ESPI_CHAN(ch)             SET_BIT(NPCX_ESPICFG, ch)
+#define DISABLE_ESPI_CHAN(ch)            CLEAR_BIT(NPCX_ESPICFG, ch)
+/* ESPI Slave Channel Support Definitions */
+#define ESPI_SUPP_CH_PC                  BIT(NPCX_ESPICFG_PCCHN_SUPP)
+#define ESPI_SUPP_CH_VM                  BIT(NPCX_ESPICFG_VWCHN_SUPP)
+#define ESPI_SUPP_CH_OOB                 BIT(NPCX_ESPICFG_OOBCHN_SUPP)
+#define ESPI_SUPP_CH_FLASH               BIT(NPCX_ESPICFG_FLASHCHN_SUPP)
+#define ESPI_SUPP_CH_ALL                 (ESPI_SUPP_CH_PC | ESPI_SUPP_CH_VM | \
+					  ESPI_SUPP_CH_OOB | ESPI_SUPP_CH_FLASH)
+/* ESPI Interrupts Enable Definitions */
+#define ESPIIE_IBRST                     BIT(NPCX_ESPIIE_IBRSTIE)
+#define ESPIIE_CFGUPD                    BIT(NPCX_ESPIIE_CFGUPDIE)
+#define ESPIIE_BERR                      BIT(NPCX_ESPIIE_BERRIE)
+#define ESPIIE_OOBRX                     BIT(NPCX_ESPIIE_OOBRXIE)
+#define ESPIIE_FLASHRX                   BIT(NPCX_ESPIIE_FLASHRXIE)
+#define ESPIIE_SFLASHRD                  BIT(NPCX_ESPIIE_SFLASHRDIE)
+#define ESPIIE_PERACC                    BIT(NPCX_ESPIIE_PERACCIE)
+#define ESPIIE_DFRD                      BIT(NPCX_ESPIIE_DFRDIE)
+#define ESPIIE_VWUPD                     BIT(NPCX_ESPIIE_VWUPDIE)
+#define ESPIIE_ESPIRST                   BIT(NPCX_ESPIIE_ESPIRSTIE)
+#define ESPIIE_PLTRST                    BIT(NPCX_ESPIIE_PLTRSTIE)
+#define ESPIIE_AMERR                     BIT(NPCX_ESPIIE_AMERRIE)
+#define ESPIIE_AMDONE                    BIT(NPCX_ESPIIE_AMDONEIE)
+#define ESPIIE_BMTXDONE                  BIT(NPCX_ESPIIE_BMTXDONEIE)
+#define ESPIIE_PBMRX                     BIT(NPCX_ESPIIE_PBMRXIE)
+#define ESPIIE_PMSGRX                    BIT(NPCX_ESPIIE_PMSGRXIE)
+#define ESPIIE_BMBURSTERR                BIT(NPCX_ESPIIE_BMBURSTERRIE)
+#define ESPIIE_BMBURSTDONE               BIT(NPCX_ESPIIE_BMBURSTDONEIE)
+/* eSPI Interrupts for VW */
+#define ESPIIE_VW                        (ESPIIE_VWUPD | ESPIIE_PLTRST)
+/* eSPI Interrupts for Generic */
+#define ESPIIE_GENERIC                   (ESPIIE_IBRST | ESPIIE_CFGUPD | \
+					  ESPIIE_BERR | ESPIIE_ESPIRST)
+/* ESPI Wake-up Enable Definitions */
+#define ESPIWE_IBRST                     BIT(NPCX_ESPIWE_IBRSTWE)
+#define ESPIWE_CFGUPD                    BIT(NPCX_ESPIWE_CFGUPDWE)
+#define ESPIWE_BERR                      BIT(NPCX_ESPIWE_BERRWE)
+#define ESPIWE_OOBRX                     BIT(NPCX_ESPIWE_OOBRXWE)
+#define ESPIWE_FLASHRX                   BIT(NPCX_ESPIWE_FLASHRXWE)
+#define ESPIWE_PERACC                    BIT(NPCX_ESPIWE_PERACCWE)
+#define ESPIWE_DFRD                      BIT(NPCX_ESPIWE_DFRDWE)
+#define ESPIWE_VWUPD                     BIT(NPCX_ESPIWE_VWUPDWE)
+#define ESPIWE_ESPIRST                   BIT(NPCX_ESPIWE_ESPIRSTWE)
+#define ESPIWE_PBMRX                     BIT(NPCX_ESPIWE_PBMRXWE)
+#define ESPIWE_PMSGRX                    BIT(NPCX_ESPIWE_PMSGRXWE)
+/* eSPI  Wake-up enable for VW */
+#define ESPIWE_VW                        ESPIWE_VWUPD
+/* eSPI  Wake-up enable for Generic */
+#define ESPIWE_GENERIC                   (ESPIWE_IBRST | ESPIWE_CFGUPD | \
+					  ESPIWE_BERR)
+/* Macro functions for eSPI VW */
+#define ESPI_VWEVMS_NUM                  12
+#define ESPI_VWEVSM_NUM                  10
+#define ESPI_VW_IDX_WIRE_NUM             4
+/* Determine Virtual Wire type */
+#define VM_TYPE(i)              ((i >= 0   && i <=  1) ? ESPI_VW_TYPE_INT_EV : \
+				 (i >= 2   && i <=  7) ? ESPI_VW_TYPE_SYS_EV : \
+				 (i >= 64  && i <= 127) ? ESPI_VW_TYPE_PLT : \
+				 (i >= 128 && i <= 255) ? ESPI_VW_TYPE_GPIO : \
+							ESPI_VW_TYPE_NONE)
+
+/* Bit field manipulation for VWEVMS Value */
+#define VWEVMS_INX(i)                ((i<<8)  & 0x00007F00)
+#define VWEVMS_INX_EN(n)             ((n<<15) & 0x00008000)
+#define VWEVMS_PLTRST_EN(p)          ((p<<17) & 0x00020000)
+#define VWEVMS_INT_EN(e)             ((e<<18) & 0x00040000)
+#define VWEVMS_ESPIRST_EN(r)         ((r<<19) & 0x00080000)
+#define VWEVMS_WK_EN(e)              ((e<<20) & 0x00100000)
+#define VWEVMS_INTWK_EN(e)           (VWEVMS_INT_EN(e) | VWEVMS_WK_EN(e))
+#define VWEVMS_FIELD(i, n, p, e, r)  (VWEVMS_INX(i) | VWEVMS_INX_EN(n) | \
+				VWEVMS_PLTRST_EN(p) | VWEVMS_INTWK_EN(e) | \
+				VWEVMS_ESPIRST_EN(r))
+#define VWEVMS_IDX_GET(reg)          (((reg & 0x00007F00)>>8))
+
+/* Bit field manipulation for VWEVSM Value */
+#define VWEVSM_VALID_N(v)            ((v<<4)  & 0x000000F0)
+#define VWEVSM_INX(i)                ((i<<8)  & 0x00007F00)
+#define VWEVSM_INX_EN(n)             ((n<<15) & 0x00008000)
+#define VWEVSM_DIRTY(d)              ((d<<16) & 0x00010000)
+#define VWEVSM_PLTRST_EN(p)          ((p<<17) & 0x00020000)
+#define VWEVSM_CDRST_EN(c)           ((c<<19) & 0x00080000)
+#define VWEVSM_FIELD(i, n, v, p, c)  (VWEVSM_INX(i) | VWEVSM_INX_EN(n) | \
+				VWEVSM_VALID_N(v) | VWEVSM_PLTRST_EN(p) |\
+				VWEVSM_CDRST_EN(c))
+#define VWEVSM_IDX_GET(reg)          (((reg & 0x00007F00)>>8))
+
+/* define macro to handle SMI/SCI Virtual Wire */
+/* Read SMI VWire status from VWEVSM(offset 2) register. */
+#define SMI_STATUS_MASK    ((uint8_t) (NPCX_VWEVSM(2) & 0x00000002))
+/*
+ * Read SCI VWire status from VWEVSM(offset 2) register.
+ * Left shift 2 to meet the SCIB field in HIPMIC register.
+ */
+#define SCI_STATUS_MASK    (((uint8_t) (NPCX_VWEVSM(2) & 0x00000001)) << 2)
+#define SCIB_MASK(v)       (v << NPCX_HIPMIC_SCIB)
+#define SMIB_MASK(v)       (v << NPCX_HIPMIC_SMIB)
+#define NPCX_VW_SCI(level)  ((NPCX_HIPMIC(PM_CHAN_1) & 0xF9) | \
+				SMI_STATUS_MASK | SCIB_MASK(level))
+#define NPCX_VW_SMI(level)  ((NPCX_HIPMIC(PM_CHAN_1) & 0xF9) | \
+				SCI_STATUS_MASK | SMIB_MASK(level))
+
+#if (FMCLK <= 33000000)
+#define NPCX_ESPI_MAXFREQ_MAX	NPCX_ESPI_MAXFREQ_33
+#else
+#define NPCX_ESPI_MAXFREQ_MAX	NPCX_ESPI_MAXFREQ_50
+#endif
+/******************************************************************************/
+/* ESPI enumeration */
+/* eSPI enumeration */
+/* eSPI channels */
+enum {
+	NPCX_ESPI_CH_PC = 0,
+	NPCX_ESPI_CH_VW,
+	NPCX_ESPI_CH_OOB,
+	NPCX_ESPI_CH_FLASH,
+	NPCX_ESPI_CH_COUNT,
+	NPCX_ESPI_CH_GENERIC,
+	NPCX_ESPI_CH_NONE = 0xFF
+};
+
+/* eSPI IO modes */
+enum {
+	NPCX_ESPI_IO_MODE_SINGLE = 0,
+	NPCX_ESPI_IO_MODE_DUAL   = 1,
+	NPCX_ESPI_IO_MODE_Quad   = 2,
+	NPCX_ESPI_IO_MODE_ALL    = 3,
+	NPCX_ESPI_IO_MODE_NONE   = 0xFF
+};
+
+/* eSPI max supported frequency */
+enum {
+	NPCX_ESPI_MAXFREQ_20   = 0,
+	NPCX_ESPI_MAXFREQ_25   = 1,
+	NPCX_ESPI_MAXFREQ_33   = 2,
+	NPCX_ESPI_MAXFREQ_50   = 3,
+	NPCX_ESPI_MAXFREQ_NOOE = 0xFF
+};
+
+/* VW types */
+enum {
+	ESPI_VW_TYPE_INT_EV,            /* Interrupt event */
+	ESPI_VW_TYPE_SYS_EV,            /* System Event */
+	ESPI_VW_TYPE_PLT,               /* Platform specific */
+	ESPI_VW_TYPE_GPIO,              /* General Purpose I/O Expander */
+	ESPI_VW_TYPE_NUM,
+	ESPI_VW_TYPE_NONE = 0xFF
+};
+
+#endif /* _NPCX_ESPI_H */

--- a/npcx/modules/gpio.h
+++ b/npcx/modules/gpio.h
@@ -1,0 +1,56 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_GPIO_H
+#define _NPCX_GPIO_H
+
+/******************************************************************************/
+/* GPIO register definitions */
+#define NPCX_PDOUT(base_addr)                 REG8((base_addr) + 0x000)
+#define NPCX_PDIN(base_addr)                  REG8((base_addr) + 0x001)
+#define NPCX_PDIR(base_addr)                  REG8((base_addr) + 0x002)
+#define NPCX_PPULL(base_addr)                 REG8((base_addr) + 0x003)
+#define NPCX_PPUD(base_addr)                  REG8((base_addr) + 0x004)
+#define NPCX_PENVDD(base_addr)                REG8((base_addr) + 0x005)
+#define NPCX_PTYPE(base_addr)                 REG8((base_addr) + 0x006)
+#define NPCX_PLOCK_CTL(base_addr)             REG8((base_addr) + 0x007)
+
+/******************************************************************************/
+/* GPIO structure/macro functions */
+
+/* Structures for mapping GPIO, low voltage controller and so on */
+struct npcx_gpio {
+	uint8_t port  : 5;
+	uint8_t bit   : 3;
+};
+
+/* Macro functions for constructions */
+#define NPCX_GPIO(grp, pin) ((struct npcx_gpio) {.port = grp, .bit = pin})
+
+/******************************************************************************/
+/* GPIO enumeration */
+
+/* GPIO ports */
+enum {
+	NPCX_GPIO_PORT_0,
+	NPCX_GPIO_PORT_1,
+	NPCX_GPIO_PORT_2,
+	NPCX_GPIO_PORT_3,
+	NPCX_GPIO_PORT_4,
+	NPCX_GPIO_PORT_5,
+	NPCX_GPIO_PORT_6,
+	NPCX_GPIO_PORT_7,
+	NPCX_GPIO_PORT_8,
+	NPCX_GPIO_PORT_9,
+	NPCX_GPIO_PORT_A,
+	NPCX_GPIO_PORT_B,
+	NPCX_GPIO_PORT_C,
+	NPCX_GPIO_PORT_D,
+	NPCX_GPIO_PORT_E,
+	NPCX_GPIO_PORT_F,
+	NPCX_GPIO_PORT_COUNT
+};
+
+#endif /* _NPCX_GPIO_H */

--- a/npcx/modules/host.h
+++ b/npcx/modules/host.h
@@ -1,0 +1,96 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_HOST_H
+#define _NPCX_HOST_H
+
+/******************************************************************************/
+/* Host-EC Interface register definitions */
+
+/* Keyboard/Mouse Interface Controller (KBC) Registers */
+#define NPCX_HICTRL(base_addr)           REG8((base_addr) + 0x000)
+#define NPCX_HIIRQC(base_addr)           REG8((base_addr) + 0x002)
+#define NPCX_HIKMST(base_addr)           REG8((base_addr) + 0x004)
+#define NPCX_HIKDO(base_addr)            REG8((base_addr) + 0x006)
+#define NPCX_HIMDO(base_addr)            REG8((base_addr) + 0x008)
+#define NPCX_KBCVER(base_addr)           REG8((base_addr) + 0x009)
+#define NPCX_HIKMDI(base_addr)           REG8((base_addr) + 0x00A)
+#define NPCX_SHIKMDI(base_addr)          REG8((base_addr) + 0x00B)
+
+/* KBC register field */
+#define NPCX_HICTRL_OBFKIE               0 /* Automatic Serial IRQ1 for KBC */
+#define NPCX_HICTRL_OBFMIE               1 /* Automatic Serial IRQ12 for Mouse*/
+#define NPCX_HICTRL_OBECIE               2 /* KBC OBE interrupt enable */
+#define NPCX_HICTRL_IBFCIE               3 /* KBC IBF interrupt enable */
+#define NPCX_HICTRL_PMIHIE               4 /* Automatic Serial IRQ11 for PMC1 */
+#define NPCX_HICTRL_PMIOCIE              5 /* PMC1 OBE interrupt enable */
+#define NPCX_HICTRL_PMICIE               6 /* PMC1 IBF interrupt enable */
+#define NPCX_HICTRL_FW_OBF               7 /* Firmware control over OBF */
+
+#define NPCX_HIKMST_OBF                  0 /* KB output buffer is full */
+
+/******************************************************************************/
+/* Power Management Channel (PM Channel) register definitions */
+#define NPCX_HIPMST(base_addr)           REG8((base_addr) + 0x000)
+#define NPCX_HIPMDO(base_addr)           REG8((base_addr) + 0x002)
+#define NPCX_HIPMDI(base_addr)           REG8((base_addr) + 0x004)
+#define NPCX_SHIPMDI(base_addr)          REG8((base_addr) + 0x005)
+#define NPCX_HIPMDOC(base_addr)          REG8((base_addr) + 0x006)
+#define NPCX_HIPMDOM(base_addr)          REG8((base_addr) + 0x008)
+#define NPCX_HIPMDIC(base_addr)          REG8((base_addr) + 0x00A)
+#define NPCX_HIPMCTL(base_addr)          REG8((base_addr) + 0x00C)
+#define NPCX_HIPMCTL2(base_addr)         REG8((base_addr) + 0x00D)
+#define NPCX_HIPMIC(base_addr)           REG8((base_addr) + 0x00E)
+#define NPCX_HIPMIE(base_addr)           REG8((base_addr) + 0x010)
+
+/* PM Channel register fields */
+#define NPCX_HIPMIE_SCIE                 1
+#define NPCX_HIPMIE_SMIE                 2
+#define NPCX_HIPMCTL_IBFIE               0
+#define NPCX_HIPMCTL_SCIPOL              6
+#define NPCX_HIPMST_F0                   2 /* EC_LPC_CMDR_BUSY */
+#define NPCX_HIPMST_ST0                  4 /* EC_LPC_CMDR_ACPI_BRST */
+#define NPCX_HIPMST_ST1                  5 /* EC_LPC_CMDR_SCI */
+#define NPCX_HIPMST_ST2                  6 /* EC_LPC_CMDR_SMI */
+#define NPCX_HIPMIC_SMIB                 1
+#define NPCX_HIPMIC_SCIB                 2
+#define NPCX_HIPMIC_SMIPOL               6
+
+/******************************************************************************/
+/* SuperI/O Internal Bus (SIB) register definitions */
+#define NPCX_IHIOA                      REG16(NPCX_SIB_BASE_ADDR + 0x000)
+#define NPCX_IHD                         REG8(NPCX_SIB_BASE_ADDR + 0x002)
+#define NPCX_LKSIOHA                    REG16(NPCX_SIB_BASE_ADDR + 0x004)
+#define NPCX_SIOLV                      REG16(NPCX_SIB_BASE_ADDR + 0x006)
+#define NPCX_CRSMAE                     REG16(NPCX_SIB_BASE_ADDR + 0x008)
+#define NPCX_SIBCTRL                     REG8(NPCX_SIB_BASE_ADDR + 0x00A)
+#define NPCX_C2H_VER                     REG8(NPCX_SIB_BASE_ADDR + 0x00E)
+/* SIB register fields  */
+#define NPCX_SIBCTRL_CSAE                0
+#define NPCX_SIBCTRL_CSRD                1
+#define NPCX_SIBCTRL_CSWR                2
+#define NPCX_LKSIOHA_LKCFG               0
+#define NPCX_LKSIOHA_LKHIKBD             11
+#define NPCX_CRSMAE_CFGAE                0
+#define NPCX_CRSMAE_HIKBDAE              11
+
+/******************************************************************************/
+/* Host-EC Interface macro functions */
+
+
+
+/******************************************************************************/
+/* Host-EC Interface enumeration */
+/*
+ * PM Channel enumeration
+ */
+enum PM_CHANNEL_T {
+	PM_CHAN_1,
+	PM_CHAN_2,
+	PM_CHAN_3,
+	PM_CHAN_4
+};
+
+#endif /* _NPCX_HOST_H */

--- a/npcx/modules/i2c.h
+++ b/npcx/modules/i2c.h
@@ -1,0 +1,143 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_I2C_H
+#define _NPCX_I2C_H
+
+/******************************************************************************/
+/* SMBus register definitions */
+#define NPCX_SMBSDA(base_addr)                REG8((base_addr) + 0x000)
+#define NPCX_SMBST(base_addr)                 REG8((base_addr) + 0x002)
+#define NPCX_SMBCST(base_addr)                REG8((base_addr) + 0x004)
+#define NPCX_SMBCTL1(base_addr)               REG8((base_addr) + 0x006)
+#define NPCX_SMBADDR1(base_addr)              REG8((base_addr) + 0x008)
+#define NPCX_SMBTMR_ST(base_addr)             REG8((base_addr) + 0x009)
+#define NPCX_SMBCTL2(base_addr)               REG8((base_addr) + 0x00A)
+#define NPCX_SMBTMR_EN(base_addr)             REG8((base_addr) + 0x00B)
+#define NPCX_SMBADDR2(base_addr)              REG8((base_addr) + 0x00C)
+#define NPCX_SMBCTL3(base_addr)               REG8((base_addr) + 0x00E)
+/* SMB Registers in bank 0 */
+#define NPCX_SMBADDR3(base_addr)              REG8((base_addr) + 0x010)
+#define NPCX_SMBADDR7(base_addr)              REG8((base_addr) + 0x011)
+#define NPCX_SMBADDR4(base_addr)              REG8((base_addr) + 0x012)
+#define NPCX_SMBADDR8(base_addr)              REG8((base_addr) + 0x013)
+#define NPCX_SMBADDR5(base_addr)              REG8((base_addr) + 0x014)
+#define NPCX_SMBADDR6(base_addr)              REG8((base_addr) + 0x016)
+#define NPCX_SMBCST2(base_addr)               REG8((base_addr) + 0x018)
+#define NPCX_SMBCST3(base_addr)               REG8((base_addr) + 0x019)
+#define NPCX_SMBCTL4(base_addr)               REG8((base_addr) + 0x01A)
+#define NPCX_SMBSCLLT(base_addr)              REG8((base_addr) + 0x01C)
+#define NPCX_SMBFIF_CTL(base_addr)            REG8((base_addr) + 0x01D)
+#define NPCX_SMBSCLHT(base_addr)              REG8((base_addr) + 0x01E)
+/* SMB Registers in bank 1 */
+#define NPCX_SMBFIF_CTS(base_addr)            REG8((base_addr) + 0x010)
+#define NPCX_SMBTXF_CTL(base_addr)            REG8((base_addr) + 0x012)
+#define NPCX_SMB_T_OUT(base_addr)             REG8((base_addr) + 0x014)
+/*
+ * These two registers are the same as in bank 0
+ * #define NPCX_SMBCST2(base_addr)            REG8((base_addr) + 0x018)
+ * #define NPCX_SMBCST3(base_addr)            REG8((base_addr) + 0x019)
+ */
+#define NPCX_SMBTXF_STS(base_addr)            REG8((base_addr) + 0x01A)
+#define NPCX_SMBRXF_STS(base_addr)            REG8((base_addr) + 0x01C)
+#define NPCX_SMBRXF_CTL(base_addr)            REG8((base_addr) + 0x01E)
+
+/* SMBus register fields */
+#define NPCX_SMBST_XMIT                       0
+#define NPCX_SMBST_MASTER                     1
+#define NPCX_SMBST_NMATCH                     2
+#define NPCX_SMBST_STASTR                     3
+#define NPCX_SMBST_NEGACK                     4
+#define NPCX_SMBST_BER                        5
+#define NPCX_SMBST_SDAST                      6
+#define NPCX_SMBST_SLVSTP                     7
+#define NPCX_SMBCST_BUSY                      0
+#define NPCX_SMBCST_BB                        1
+#define NPCX_SMBCST_MATCH                     2
+#define NPCX_SMBCST_GCMATCH                   3
+#define NPCX_SMBCST_TSDA                      4
+#define NPCX_SMBCST_TGSCL                     5
+#define NPCX_SMBCST_MATCHAF                   6
+#define NPCX_SMBCST_ARPMATCH                  7
+#define NPCX_SMBCST2_MATCHA1F                 0
+#define NPCX_SMBCST2_MATCHA2F                 1
+#define NPCX_SMBCST2_MATCHA3F                 2
+#define NPCX_SMBCST2_MATCHA4F                 3
+#define NPCX_SMBCST2_MATCHA5F                 4
+#define NPCX_SMBCST2_MATCHA6F                 5
+#define NPCX_SMBCST2_MATCHA7F                 6
+#define NPCX_SMBCST2_INTSTS                   7
+#define NPCX_SMBCST3_MATCHA8F                 0
+#define NPCX_SMBCST3_MATCHA9F                 1
+#define NPCX_SMBCST3_MATCHA10F                2
+#define NPCX_SMBCTL1_START                    0
+#define NPCX_SMBCTL1_STOP                     1
+#define NPCX_SMBCTL1_INTEN                    2
+#define NPCX_SMBCTL1_ACK                      4
+#define NPCX_SMBCTL1_GCMEN                    5
+#define NPCX_SMBCTL1_NMINTE                   6
+#define NPCX_SMBCTL1_STASTRE                  7
+#define NPCX_SMBCTL2_ENABLE                   0
+#define NPCX_SMBCTL2_SCLFRQ7_FIELD            FIELD(1, 7)
+#define NPCX_SMBCTL3_ARPMEN                   2
+#define NPCX_SMBCTL3_SCLFRQ2_FIELD            FIELD(0, 2)
+#define NPCX_SMBCTL3_IDL_START                3
+#define NPCX_SMBCTL3_400K                     4
+#define NPCX_SMBCTL3_BNK_SEL                  5
+#define NPCX_SMBCTL3_SDA_LVL                  6
+#define NPCX_SMBCTL3_SCL_LVL                  7
+#define NPCX_SMBCTL4_HLDT_FIELD               FIELD(0, 6)
+#define NPCX_SMBCTL4_LVL_WE                   7
+#define NPCX_SMBADDR1_SAEN                    7
+#define NPCX_SMBADDR2_SAEN                    7
+#define NPCX_SMBADDR3_SAEN                    7
+#define NPCX_SMBADDR4_SAEN                    7
+#define NPCX_SMBADDR5_SAEN                    7
+#define NPCX_SMBADDR6_SAEN                    7
+#define NPCX_SMBADDR7_SAEN                    7
+#define NPCX_SMBADDR8_SAEN                    7
+#define NPCX_SMBSEL_SMB4SEL                   4
+#define NPCX_SMBSEL_SMB5SEL                   5
+#define NPCX_SMBSEL_SMB6SEL                   6
+#define NPCX_SMBFIF_CTS_RXF_TXE               1
+#define NPCX_SMBFIF_CTS_CLR_FIFO              6
+
+#define NPCX_SMBFIF_CTL_FIFO_EN               4
+
+#define NPCX_SMBRXF_STS_RX_THST               6
+
+/* RX FIFO threshold */
+#define NPCX_SMBRXF_CTL_RX_THR                FIELD(0, 6)
+/*
+ * In master receiving mode, last byte in FIFO should send ACK or NACK
+ */
+#define NPCX_SMBRXF_CTL_LAST                  7
+
+
+/******************************************************************************/
+/* SMBus macro functions */
+
+/******************************************************************************/
+/* SMBus enumeration */
+/*
+ * SMB enumeration
+ * I2C port definitions.
+ */
+enum {
+	NPCX_I2C_PORT0_0  = 0, /* I2C port 0, bus 0 */
+	NPCX_I2C_PORT1_0,      /* I2C port 1, bus 0 */
+	NPCX_I2C_PORT2_0,      /* I2C port 2, bus 0 */
+	NPCX_I2C_PORT3_0,      /* I2C port 3, bus 0 */
+	NPCX_I2C_PORT4_0,      /* I2C port 4, bus 0 */
+	NPCX_I2C_PORT4_1,      /* I2C port 4, bus 1 */
+	NPCX_I2C_PORT5_0,      /* I2C port 5, bus 0 */
+	NPCX_I2C_PORT5_1,      /* I2C port 5, bus 1 */
+	NPCX_I2C_PORT6_0,      /* I2C port 6, bus 0 */
+	NPCX_I2C_PORT6_1,      /* I2C port 6, bus 1 */
+	NPCX_I2C_PORT7_0,      /* I2C port 7, bus 0 */
+	NPCX_I2C_COUNT,
+};
+
+#endif /* _NPCX_I2C_H */

--- a/npcx/modules/itim.h
+++ b/npcx/modules/itim.h
@@ -1,0 +1,44 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_ITIM_H
+#define _NPCX_ITIM_H
+
+/******************************************************************************/
+/* Internal 16/32 bits Timer (ITIM) register definitions */
+/* ITIM16 registers */
+#define NPCX_ITCNT(base_addr)                 REG8((base_addr) + 0x000)
+#define NPCX_ITPRE(base_addr)                 REG8((base_addr) + 0x001)
+#define NPCX_ITCNT16(base_addr)              REG16((base_addr) + 0x002)
+#define NPCX_ITCTS(base_addr)                 REG8((base_addr) + 0x004)
+
+/* ITIM32 registers */
+#define NPCX_ITCNT32                         REG32((base_addr) + 0x008)
+
+/* ITIM16 register fields */
+#define NPCX_ITCTS_TO_STS                     0
+#define NPCX_ITCTS_TO_IE                      2
+#define NPCX_ITCTS_TO_WUE                     3
+#define NPCX_ITCTS_CKSEL                      4
+#define NPCX_ITCTS_ITEN                       7
+
+/******************************************************************************/
+/* ITIM macro functions */
+#define ITIM16_INT(module)               CONCAT2(NPCX_IRQ_, module)
+
+/******************************************************************************/
+/* ITIM enumeration */
+enum {
+	ITIM16_1,
+	ITIM16_2,
+	ITIM16_3,
+	ITIM16_4,
+	ITIM16_5,
+	ITIM16_6,
+	ITIM32,
+	ITIM_MODULE_COUNT,
+};
+
+#endif /* _NPCX_ITIM_H */

--- a/npcx/modules/kbscan.h
+++ b/npcx/modules/kbscan.h
@@ -1,0 +1,43 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_KBSCAN_H
+#define _NPCX_KBSCAN_H
+
+/******************************************************************************/
+/* Keyboard Scan (KBSCAN) register definitions */
+#define NPCX_KBSIN(base_addr)                 REG8((base_addr) + 0x04)
+#define NPCX_KBSINPU(base_addr)               REG8((base_addr) + 0x05)
+#define NPCX_KBSOUT0(base_addr)              REG16((base_addr) + 0x06)
+#define NPCX_KBSOUT1(base_addr)              REG16((base_addr) + 0x08)
+#define NPCX_KBS_BUF_INDX(base_addr)          REG8((base_addr) + 0x0A)
+#define NPCX_KBS_BUF_DATA(base_addr)          REG8((base_addr) + 0x0B)
+#define NPCX_KBSEVT(base_addr)                REG8((base_addr) + 0x0C)
+#define NPCX_KBSCTL(base_addr)                REG8((base_addr) + 0x0D)
+#define NPCX_KBS_CFG_INDX(base_addr)          REG8((base_addr) + 0x0E)
+#define NPCX_KBS_CFG_DATA(base_addr)          REG8((base_addr) + 0x0F)
+
+/* KBSCAN register fields */
+#define NPCX_KBSBUFINDX                       0
+#define NPCX_KBSDONE                          0
+#define NPCX_KBSERR                           1
+#define NPCX_KBSSTART                         0
+#define NPCX_KBSMODE                          1
+#define NPCX_KBSIEN                           2
+#define NPCX_KBSINC                           3
+#define NPCX_KBHDRV_FIELD                     FIELD(6, 2)
+#define NPCX_KBSCFGINDX                       0
+
+/******************************************************************************/
+/* KBSCAN macro functions */
+#define NPCX_KB_ROW_NUM  8  /* Rows numbers of keyboard matrix */
+#define NPCX_KB_COL_NUM  18 /* Columns numbers of keyboard matrix */
+/* Mask of rows of keyboard matrix */
+#define NPCX_KB_ROW_MASK ((1<<KB_ROW_NUM) - 1)
+
+/******************************************************************************/
+/* KBSCAN enumeration */
+
+#endif /* _NPCX_KBSCAN_H */

--- a/npcx/modules/mft.h
+++ b/npcx/modules/mft.h
@@ -1,0 +1,59 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_MFT_H
+#define _NPCX_MFT_H
+
+/******************************************************************************/
+/* Multi-Function Timer (MFT) register definitions */
+#define NPCX_TCNT1(base_addr)                REG16((base_addr) + 0x000)
+#define NPCX_TCRA(base_addr)                 REG16((base_addr) + 0x002)
+#define NPCX_TCRB(base_addr)                 REG16((base_addr) + 0x004)
+#define NPCX_TCNT2(base_addr)                REG16((base_addr) + 0x006)
+#define NPCX_TPRSC(base_addr)                 REG8((base_addr) + 0x008)
+#define NPCX_TCKC(base_addr)                  REG8((base_addr) + 0x00A)
+#define NPCX_TMCTRL(base_addr)                REG8((base_addr) + 0x00C)
+#define NPCX_TECTRL(base_addr)                REG8((base_addr) + 0x00E)
+#define NPCX_TECLR(base_addr)                 REG8((base_addr) + 0x010)
+#define NPCX_TIEN(base_addr)                  REG8((base_addr) + 0x012)
+#define NPCX_TWUEN(base_addr)                 REG8((base_addr) + 0x01A)
+#define NPCX_TCFG(base_addr)                  REG8((base_addr) + 0x01C)
+
+/* MFT register fields */
+#define NPCX_TMCTRL_MDSEL_FIELD               FIELD(0, 3)
+#define NPCX_TCKC_LOW_PWR                     7
+#define NPCX_TCKC_PLS_ACC_CLK                 6
+#define NPCX_TCKC_C1CSEL_FIELD                FIELD(0, 3)
+#define NPCX_TCKC_C2CSEL_FIELD                FIELD(3, 3)
+#define NPCX_TMCTRL_TAEN                      5
+#define NPCX_TMCTRL_TBEN                      6
+#define NPCX_TMCTRL_TAEDG                     3
+#define NPCX_TMCTRL_TBEDG                     4
+#define NPCX_TCFG_TADBEN                      6
+#define NPCX_TCFG_TBDBEN                      7
+#define NPCX_TECTRL_TAPND                     0
+#define NPCX_TECTRL_TBPND                     1
+#define NPCX_TECTRL_TCPND                     2
+#define NPCX_TECTRL_TDPND                     3
+#define NPCX_TECLR_TACLR                      0
+#define NPCX_TECLR_TBCLR                      1
+#define NPCX_TECLR_TCCLR                      2
+#define NPCX_TECLR_TDCLR                      3
+#define NPCX_TIEN_TAIEN                       0
+#define NPCX_TIEN_TBIEN                       1
+#define NPCX_TIEN_TCIEN                       2
+#define NPCX_TIEN_TDIEN                       3
+#define NPCX_TWUEN_TAWEN                      0
+#define NPCX_TWUEN_TBWEN                      1
+#define NPCX_TWUEN_TCWEN                      2
+#define NPCX_TWUEN_TDWEN                      3
+
+/******************************************************************************/
+/* MFT macro functions */
+
+/******************************************************************************/
+/* MFT enumeration */
+
+#endif /* _NPCX_MFT_H */

--- a/npcx/modules/miwu.h
+++ b/npcx/modules/miwu.h
@@ -1,0 +1,69 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_MIWU_H
+#define _NPCX_MIWU_H
+
+/******************************************************************************/
+/* MIWU register definitions */
+#define NPCX_WKEDG_ADDR(base_addr, n)    ((base_addr) + 0x00 + \
+					      ((n) * 2L) + ((n) < 5 ? 0 : 0x1E))
+#define NPCX_WKAEDG_ADDR(base_addr, n)   ((base_addr) + 0x01 + \
+					      ((n) * 2L) + ((n) < 5 ? 0 : 0x1E))
+#define NPCX_WKPND_ADDR(base_addr, n)    ((base_addr) + 0x0A + \
+					      ((n) * 4L) + ((n) < 5 ? 0 : 0x10))
+#define NPCX_WKPCL_ADDR(base_addr, n)    ((base_addr) + 0x0C + \
+					      ((n) * 4L) + ((n) < 5 ? 0 : 0x10))
+#define NPCX_WKEN_ADDR(base_addr, n)     ((base_addr) + 0x1E + \
+					      ((n) * 2L) + ((n) < 5 ? 0 : 0x12))
+#define NPCX_WKINEN_ADDR(base_addr, n)   ((base_addr) + 0x1F + \
+					     ((n) * 2L) + ((n) < 5 ? 0 : 0x12))
+#define NPCX_WKMOD_ADDR(base_addr, n)    ((base_addr) + 0x70 + (n))
+
+#define NPCX_WKEDG(base_addr, n)         REG8(NPCX_WKEDG_ADDR(base_addr, n))
+#define NPCX_WKAEDG(base_addr, n)        REG8(NPCX_WKAEDG_ADDR(base_addr, n))
+#define NPCX_WKPND(base_addr, n)         REG8(NPCX_WKPND_ADDR(base_addr, n))
+#define NPCX_WKPCL(base_addr, n)         REG8(NPCX_WKPCL_ADDR(base_addr, n))
+#define NPCX_WKEN(base_addr, n)          REG8(NPCX_WKEN_ADDR(base_addr, n))
+#define NPCX_WKINEN(base_addr, n)        REG8(NPCX_WKINEN_ADDR(base_addr, n))
+#define NPCX_WKMOD(base_addr, n)         REG8(NPCX_WKMOD_ADDR(base_addr, n))
+
+/******************************************************************************/
+/* MIWU structure/macro functions */
+/* Structure for MIWU WUI item */
+struct npcx_wui {
+	uint8_t table : 2;
+	uint8_t group : 3;
+	uint8_t bit   : 3;
+};
+
+/* Macro functions for constructions */
+#define NPCX_WUI(tbl, grp, idx) ((struct npcx_wui) { .table = tbl, \
+						.group = grp, .bit = idx })
+
+/******************************************************************************/
+/* MIWU enumeration */
+/* MIWU Tables */
+enum {
+	NPCX_MIWU_TABLE_0,
+	NPCX_MIWU_TABLE_1,
+	NPCX_MIWU_TABLE_2,
+	NPCX_MIWU_TABLE_COUNT
+};
+
+/* MIWU Groups */
+enum {
+	NPCX_MIWU_GROUP_1,
+	NPCX_MIWU_GROUP_2,
+	NPCX_MIWU_GROUP_3,
+	NPCX_MIWU_GROUP_4,
+	NPCX_MIWU_GROUP_5,
+	NPCX_MIWU_GROUP_6,
+	NPCX_MIWU_GROUP_7,
+	NPCX_MIWU_GROUP_8,
+	NPCX_MIWU_GROUP_COUNT
+};
+
+#endif /* _NPCX_MIWU_H */

--- a/npcx/modules/pwm.h
+++ b/npcx/modules/pwm.h
@@ -1,0 +1,55 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_PWM_H
+#define _NPCX_PWM_H
+
+/******************************************************************************/
+/* PWM register definitions */
+#define NPCX_PRSC(base_addr)                 REG16((base_addr) + 0x000)
+#define NPCX_CTR(base_addr)                  REG16((base_addr) + 0x002)
+#define NPCX_PWMCTL(base_addr)                REG8((base_addr) + 0x004)
+#define NPCX_DCR(base_addr)                  REG16((base_addr) + 0x006)
+#define NPCX_PWMCTLEX(base_addr)              REG8((base_addr) + 0x00C)
+
+/* PWM register fields */
+#define NPCX_PWMCTL_INVP                      0
+#define NPCX_PWMCTL_CKSEL                     1
+#define NPCX_PWMCTL_HB_DC_CTL_FIELD           FIELD(2, 2)
+#define NPCX_PWMCTL_PWR                       7
+#define NPCX_PWMCTLEX_FCK_SEL_FIELD           FIELD(4, 2)
+#define NPCX_PWMCTLEX_OD_OUT                  7
+
+/******************************************************************************/
+/* PWM macro functions */
+
+/* 16-bit prescaler in NPCX PWM modules */
+#define NPCX_PWM_MAX_PRESCALER      (1UL << (16))
+
+/* 16-bit period cycles in NPCX PWM modules */
+#define NPCX_PWM_MAX_PERIOD_CYCLES  (1UL << (16))
+
+/******************************************************************************/
+/* PWM enumeration */
+
+/* PWM clock source */
+enum {
+	NPCX_PWM_CLOCK_APB2_LFCLK  = 0,
+	NPCX_PWM_CLOCK_FX          = 1,
+	NPCX_PWM_CLOCK_FR          = 2,
+	NPCX_PWM_CLOCK_RESERVED    = 3,
+	NPCX_PWM_CLOCK_UNDEF       = 0xFF
+};
+
+/* PWM heartbeat mode */
+enum {
+	NPCX_PWM_HBM_NORMAL    = 0,
+	NPCX_PWM_HBM_25        = 1,
+	NPCX_PWM_HBM_50        = 2,
+	NPCX_PWM_HBM_100       = 3,
+	NPCX_PWM_HBM_UNDEF     = 0xFF
+};
+
+#endif /* _NPCX_PWM_H */

--- a/npcx/modules/scfg.h
+++ b/npcx/modules/scfg.h
@@ -1,0 +1,236 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_SCFG_H
+#define _NPCX_SCFG_H
+
+/******************************************************************************/
+/* System Configuration (SCFG) register definitions */
+#define NPCX_DEVCNT(base_addr)                REG8((base_addr) + 0x000)
+#define NPCX_STRPST(base_addr)                REG8((base_addr) + 0x001)
+#define NPCX_RSTCTL(base_addr)                REG8((base_addr) + 0x002)
+#define NPCX_DEV_CTL4(base_addr)              REG8((base_addr) + 0x006)
+#define NPCX_DEVALT(base_addr, n)             REG8((base_addr) + 0x010 + (n))
+#define NPCX_LFCGCALCNT(base_addr)            REG8((base_addr) + 0x021)
+#define NPCX_PUPD_EN0(base_addr)              REG8((base_addr) + 0x028)
+#define NPCX_PUPD_EN1(base_addr)              REG8((base_addr) + 0x029)
+#define NPCX_SCFG_VER                         REG8((base_addr) + 0x02F)
+#define NPCX_LV_GPIO_CTL_ADDR(base_addr, n)   (((n) < 5) ? \
+					          ((base_addr) + 0x02A + (n)) :\
+					          ((base_addr) + 0x026))
+#define NPCX_LV_GPIO_CTL(base_addr, n)        REG8(NPCX_LV_GPIO_CTL_ADDR \
+						                 (base_addr, n))
+#define TEST_BKSL(base_addr)                  REG8((base_addr) + 0x037)
+#define TEST0(base_addr)                      REG8((base_addr) + 0x038)
+#define BLKSEL(base_addr)                     0
+
+/* SCFG register fields */
+#define NPCX_DEVCNT_F_SPI_TRIS                6
+#define NPCX_DEVCNT_HIF_TYP_SEL_FIELD         FIELD(2, 2)
+#define NPCX_DEVCNT_JEN1_HEN                  5
+#define NPCX_DEVCNT_JEN0_HEN                  4
+#define NPCX_STRPST_TRIST                     1
+#define NPCX_STRPST_TEST                      2
+#define NPCX_STRPST_JEN1                      4
+#define NPCX_STRPST_JEN0                      5
+#define NPCX_STRPST_SPI_COMP                  7
+#define NPCX_RSTCTL_VCC1_RST_STS              0
+#define NPCX_RSTCTL_DBGRST_STS                1
+#define NPCX_RSTCTL_VCC1_RST_SCRATCH          3
+#define NPCX_RSTCTL_LRESET_PLTRST_MODE        5
+#define NPCX_RSTCTL_HIPRST_MODE               6
+#define NPCX_DEV_CTL4_F_SPI_SLLK              2
+#define NPCX_DEV_CTL4_SPI_SP_SEL              4
+#define NPCX_DEV_CTL4_WP_IF                   5
+#define NPCX_DEV_CTL4_VCC1_RST_LK             6
+#define NPCX_DEVPU0_I2C0_0_PUE                0
+#define NPCX_DEVPU0_I2C0_1_PUE                1
+#define NPCX_DEVPU0_I2C1_0_PUE                2
+#define NPCX_DEVPU0_I2C2_0_PUE                4
+#define NPCX_DEVPU0_I2C3_0_PUE                6
+#define NPCX_DEVPU1_F_SPI_PUD_EN              7
+
+/* DEVALT */
+/* pin-mux for SPI/FIU */
+#define NPCX_DEVALT0_SPIP_SL                  0
+#define NPCX_DEVALT0_GPIO_NO_SPIP             3
+#define NPCX_DEVALT0_F_SPI_CS1_2              4
+#define NPCX_DEVALT0_F_SPI_CS1_1              5
+#define NPCX_DEVALT0_F_SPI_QUAD               6
+#define NPCX_DEVALT0_NO_F_SPI                 7
+
+/* pin-mux for LPC/eSPI */
+#define NPCX_DEVALT1_KBRST_SL                 0
+#define NPCX_DEVALT1_A20M_SL                  1
+#define NPCX_DEVALT1_SMI_SL                   2
+#define NPCX_DEVALT1_EC_SCI_SL                3
+#define NPCX_DEVALT1_NO_PWRGD                 4
+#define NPCX_DEVALT1_RST_OUT_SL               5
+#define NPCX_DEVALT1_CLKRN_SL                 6
+#define NPCX_DEVALT1_NO_LPC_ESPI              7
+
+/* pin-mux for I2C */
+#define NPCX_DEVALT2_I2C0_0_SL                0
+#define NPCX_DEVALT2_I2C7_0_SL                1
+#define NPCX_DEVALT2_I2C1_0_SL                2
+#define NPCX_DEVALT2_I2C6_0_SL                3
+#define NPCX_DEVALT2_I2C2_0_SL                4
+#define NPCX_DEVALT2_I2C5_0_SL                5
+#define NPCX_DEVALT2_I2C3_0_SL                6
+#define NPCX_DEVALT2_I2C4_0_SL                7
+#define NPCX_DEVALT6_I2C6_1_SL                5
+#define NPCX_DEVALT6_I2C5_1_SL                6
+#define NPCX_DEVALT6_I2C4_1_SL                7
+
+/* pin-mux for PS2 */
+#define NPCX_DEVALT3_PS2_0_SL                 0
+#define NPCX_DEVALT3_PS2_1_SL                 1
+#define NPCX_DEVALT3_PS2_2_SL                 2
+#define NPCX_DEVALT3_PS2_3_SL                 3
+#define NPCX_DEVALTC_PS2_3_SL2                3
+
+/* pin-mux for Tacho */
+#define NPCX_DEVALT3_TA1_SL1                  4
+#define NPCX_DEVALT3_TB1_SL1                  5
+#define NPCX_DEVALT3_TA2_SL1                  6
+#define NPCX_DEVALT3_TB2_SL1                  7
+#define NPCX_DEVALTC_TA1_SL2                  4
+#define NPCX_DEVALTC_TB1_SL2                  5
+#define NPCX_DEVALTC_TA2_SL2                  6
+#define NPCX_DEVALTC_TB2_SL2                  7
+
+/* pin-mux for PWM */
+#define NPCX_DEVALT4_PWM0_SL                  0
+#define NPCX_DEVALT4_PWM1_SL                  1
+#define NPCX_DEVALT4_PWM2_SL                  2
+#define NPCX_DEVALT4_PWM3_SL                  3
+#define NPCX_DEVALT4_PWM4_SL                  4
+#define NPCX_DEVALT4_PWM5_SL                  5
+#define NPCX_DEVALT4_PWM6_SL                  6
+#define NPCX_DEVALT4_PWM7_SL                  7
+
+/* pin-mux for JTAG */
+#define NPCX_DEVALT5_TRACE_EN                 0
+#define NPCX_DEVALT5_NJEN1_EN                 1
+#define NPCX_DEVALT5_NJEN0_EN                 2
+
+/* pin-mux for ADC */
+#define NPCX_DEVALT6_ADC0_SL                  0
+#define NPCX_DEVALT6_ADC1_SL                  1
+#define NPCX_DEVALT6_ADC2_SL                  2
+#define NPCX_DEVALT6_ADC3_SL                  3
+#define NPCX_DEVALT6_ADC4_SL                  4
+#define NPCX_DEVALTF_ADC5_SL                  0
+#define NPCX_DEVALTF_ADC6_SL                  1
+#define NPCX_DEVALTF_ADC7_SL                  2
+#define NPCX_DEVALTF_ADC8_SL                  3
+#define NPCX_DEVALTF_ADC9_SL                  4
+
+/* pin-mux for Keyboard */
+#define NPCX_DEVALT7_NO_KSI0_SL               0
+#define NPCX_DEVALT7_NO_KSI1_SL               1
+#define NPCX_DEVALT7_NO_KSI2_SL               2
+#define NPCX_DEVALT7_NO_KSI3_SL               3
+#define NPCX_DEVALT7_NO_KSI4_SL               4
+#define NPCX_DEVALT7_NO_KSI5_SL               5
+#define NPCX_DEVALT7_NO_KSI6_SL               6
+#define NPCX_DEVALT7_NO_KSI7_SL               7
+#define NPCX_DEVALT8_NO_KSO00_SL              0
+#define NPCX_DEVALT8_NO_KSO01_SL              1
+#define NPCX_DEVALT8_NO_KSO02_SL              2
+#define NPCX_DEVALT8_NO_KSO03_SL              3
+#define NPCX_DEVALT8_NO_KSO04_SL              4
+#define NPCX_DEVALT8_NO_KSO05_SL              5
+#define NPCX_DEVALT8_NO_KSO06_SL              6
+#define NPCX_DEVALT8_NO_KSO07_SL              7
+#define NPCX_DEVALT9_NO_KSO08_SL              0
+#define NPCX_DEVALT9_NO_KSO09_SL              1
+#define NPCX_DEVALT9_NO_KSO10_SL              2
+#define NPCX_DEVALT9_NO_KSO11_SL              3
+#define NPCX_DEVALT9_NO_KSO12_SL              4
+#define NPCX_DEVALT9_NO_KSO13_SL              5
+#define NPCX_DEVALT9_NO_KSO14_SL              6
+#define NPCX_DEVALT9_NO_KSO15_SL              7
+#define NPCX_DEVALTA_NO_KSO16_SL              0
+#define NPCX_DEVALTA_NO_KSO17_SL              1
+
+/* pin-mux for PSL */
+#define NPCX_DEVALTD_PSL_IN1_AHI              0
+#define NPCX_DEVALTD_NPSL_IN1_SL              1
+#define NPCX_DEVALTD_PSL_IN2_AHI              2
+#define NPCX_DEVALTD_NPSL_IN2_SL              3
+#define NPCX_DEVALTD_PSL_IN3_AHI              4
+#define NPCX_DEVALTD_PSL_IN3_SL               5
+#define NPCX_DEVALTD_PSL_IN4_AHI              6
+#define NPCX_DEVALTD_PSL_IN4_SL               7
+
+/* pin-mux for Others */
+#define NPCX_DEVALTA_32K_OUT_SL               2
+#define NPCX_DEVALTA_32KCLKIN_SL              3
+#define NPCX_DEVALTA_NO_VCC1_RST              4
+#define NPCX_DEVALTA_UART2_SL                 5
+#define NPCX_DEVALTA_NO_PECI_EN               6
+#define NPCX_DEVALTA_UART_SL1                 7
+#define NPCX_DEVALTC_UART_SL2                 0
+#define NPCX_DEVALTC_SHI_SL                   1
+
+/* SHI module version 2 enable bit */
+#define NPCX_DEVALTF_SHI_NEW                  7
+
+/* pin-mux for WoV */
+#define NPCX_DEVALTE_WOV_SL                   0
+#define NPCX_DEVALTE_I2S_SL                   1
+#define NPCX_DEVALTE_DMCLK_FAST               2
+
+/* Others bit definitions */
+#define NPCX_LFCGCALCNT_LPREG_CTL_EN          1
+
+/******************************************************************************/
+/* SCFG structure/macro functions */
+/* Structure for pin-muxing */
+struct npcx_alt {
+	uint8_t group     : 4;
+	uint8_t bit       : 3;
+	uint8_t inverted  : 1;
+};
+
+/* Structure for low voltage control */
+struct npcx_lvol {
+	uint8_t ctrl      : 5;
+	uint8_t bit       : 3;
+};
+
+struct gpio_lvol_map {
+	struct npcx_gpio gpio;
+	struct npcx_lvol lvol;
+};
+
+/* Macro functions for constructions */
+#define NPCX_LVOL(ctl, pin) ((struct npcx_lvol) {.ctrl = ctl, .bit = pin})
+
+/******************************************************************************/
+/* SCFG enumeration */
+/* ALT Groups */
+enum {
+	ALT_GROUP_0,
+	ALT_GROUP_1,
+	ALT_GROUP_2,
+	ALT_GROUP_3,
+	ALT_GROUP_4,
+	ALT_GROUP_5,
+	ALT_GROUP_6,
+	ALT_GROUP_7,
+	ALT_GROUP_8,
+	ALT_GROUP_9,
+	ALT_GROUP_A,
+	ALT_GROUP_B,
+	ALT_GROUP_C,
+	ALT_GROUP_D,
+	ALT_GROUP_E,
+	ALT_GROUP_F,
+	ALT_GROUP_COUNT
+};
+
+#endif /* _NPCX_SCFG_H */

--- a/npcx/modules/uart.h
+++ b/npcx/modules/uart.h
@@ -1,0 +1,109 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_UART_H
+#define _NPCX_UART_H
+
+/******************************************************************************/
+/* UART register definitions */
+#define NPCX_UTBUF(base_addr)                 REG8((base_addr) + 0x000)
+#define NPCX_URBUF(base_addr)                 REG8((base_addr) + 0x002)
+#define NPCX_UICTRL(base_addr)                REG8((base_addr) + 0x004)
+#define NPCX_USTAT(base_addr)                 REG8((base_addr) + 0x006)
+#define NPCX_UFRS(base_addr)                  REG8((base_addr) + 0x008)
+#define NPCX_UMDSL(base_addr)                 REG8((base_addr) + 0x00A)
+#define NPCX_UBAUD(base_addr)                 REG8((base_addr) + 0x00C)
+#define NPCX_UPSR(base_addr)                  REG8((base_addr) + 0x00E)
+/* UART registers only used for FIFO mode */
+#define NPCX_UFTSTS(base_addr)                REG8((base_addr) + 0x020)
+#define NPCX_UFRSTS(base_addr)                REG8((base_addr) + 0x022)
+#define NPCX_UFTCTL(base_addr)                REG8((base_addr) + 0x024)
+#define NPCX_UFRCTL(base_addr)                REG8((base_addr) + 0x026)
+
+/* UART register fields */
+#define NPCX_UICTRL_TBE                       0
+#define NPCX_UICTRL_RBF                       1
+#define NPCX_UICTRL_ETI                       5
+#define NPCX_UICTRL_ERI                       6
+#define NPCX_UICTRL_EEI                       7
+
+#define NPCX_USTAT_PE                         0
+#define NPCX_USTAT_FE                         1
+#define NPCX_USTAT_DOE                        2
+#define NPCX_USTAT_ERR                        3
+#define NPCX_USTAT_BKD                        4
+#define NPCX_USTAT_RB9                        5
+#define NPCX_USTAT_XMIP                       6
+
+#define NPCX_UFRS_CHAR_FIELD                  FIELD(0, 2)
+#define NPCX_UFRS_STP                         2
+#define NPCX_UFRS_XB9                         3
+#define NPCX_UFRS_PSEL_FIELD                  FIELD(4, 2)
+#define NPCX_UFRS_PEN                         6
+
+/* UART FIFO register fields */
+#define NPCX_UMDSL_FIFO_MD                    0
+
+#define NPCX_UFTSTS_TEMPTY_LVL                FIELD(0, 5)
+#define NPCX_UFTSTS_TEMPTY_LVL_STS            5
+#define NPCX_UFTSTS_TFIFO_EMPTY_STS           6
+#define NPCX_UFTSTS_NXMIP                     7
+
+#define NPCX_UFRSTS_RFULL_LVL_STS             5
+#define NPCX_UFRSTS_RFIFO_NEMPTY_STS          6
+#define NPCX_UFRSTS_ERR                       7
+
+#define NPCX_UFTCTL_TEMPTY_LVL_SEL            FIELD(0, 5)
+#define NPCX_UFTCTL_TEMPTY_LVL_EN             5
+#define NPCX_UFTCTL_TEMPTY_EN                 6
+#define NPCX_UFTCTL_NXMIPEN                   7
+
+#define NPCX_UFRCTL_RFULL_LVL_SEL             FIELD(0, 5)
+#define NPCX_UFRCTL_RFULL_LVL_EN              5
+#define NPCX_UFRCTL_RNEMPTY_EN                6
+#define NPCX_UFRCTL_ERR_EN                    7
+
+/******************************************************************************/
+/* UART Tx FIFO macro functions */
+/* Enable UART Tx FIFO empty interrupt */
+#define NPCX_UART_TX_FIFO_EMPTY_INT_EN(n)      \
+		(SET_BIT(NPCX_UFTCTL(n), NPCX_UFTCTL_TEMPTY_EN))
+/* True if UART Tx FIFO empty interrupt is enabled */
+#define NPCX_UART_TX_FIFO_EMPTY_INT_IS_EN(n)   \
+		(IS_BIT_SET(NPCX_UFTCTL(n), NPCX_UFTCTL_TEMPTY_EN))
+/* Disable UART Tx FIFO empty interrupt */
+#define NPCX_UART_TX_FIFO_EMPTY_INT_DIS(n)     \
+		(CLEAR_BIT(NPCX_UFTCTL(n), NPCX_UFTCTL_TEMPTY_EN))
+/* True if the Tx FIFO is not completely full */
+#define NPCX_UART_TX_FIFO_IS_READY(n)          \
+		(!(GET_FIELD(NPCX_UFTSTS(n), NPCX_UFTSTS_TEMPTY_LVL) == 0))
+/*
+ * True if Tx is in progress
+ * (i.e. FIFO is not empty or last byte in TSFT (Transmit Shift register)
+ * is not sent)
+ */
+#define NPCX_UART_TX_FIFO_IN_XMIT(n)           \
+		(!IS_BIT_SET(NPCX_UFTSTS(n), NPCX_UFTSTS_NXMIP))
+
+
+/* UART Rx FIFO macro functions */
+/*
+ * Enable to generate interrupt when there is at least one byte
+ * in the receive FIFO
+ */
+#define NPCX_UART_RX_FIFO_NO_EMPTY_INT_EN(n)    \
+		(SET_BIT(NPCX_UFRCTL(n), NPCX_UFRCTL_RNEMPTY_EN))
+
+#define NPCX_UART_RX_FIFO_NO_EMPTY_INT_DIS(n)   \
+		(CLEAR_BIT(NPCX_UFRCTL(n), NPCX_UFRCTL_RNEMPTY_EN))
+
+#define NPCX_UART_RX_FIFO_NO_EMPTY_INT_IS_EN(n) \
+		(IS_BIT_SET(NPCX_UFRCTL(n), NPCX_UFRCTL_RNEMPTY_EN))
+
+/* True if at least one byte is in the receive FIFO */
+#define NPCX_UART_RX_FIFO_IS_AVAILABLE(n)      \
+		(IS_BIT_SET(NPCX_UFRSTS(n), NPCX_UFRSTS_RFIFO_NEMPTY_STS))
+
+#endif /* _NPCX_UART_H */

--- a/npcx/modules/watchdog.h
+++ b/npcx/modules/watchdog.h
@@ -1,0 +1,41 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef _NPCX_WATCHDOG_H
+#define _NPCX_WATCHDOG_H
+
+/******************************************************************************/
+/* Timer Watchdog (TWD) register definitions */
+#define NPCX_TWCFG(base_addr)                  REG8((base_addr) + 0x000)
+#define NPCX_TWCP(base_addr)                   REG8((base_addr) + 0x002)
+#define NPCX_TWDT0(base_addr)                 REG16((base_addr) + 0x004)
+#define NPCX_T0CSR(base_addr)                  REG8((base_addr) + 0x006)
+#define NPCX_WDCNT(base_addr)                  REG8((base_addr) + 0x008)
+#define NPCX_WDSDM(base_addr)                  REG8((base_addr) + 0x00A)
+#define NPCX_TWMT0(base_addr)                 REG16((base_addr) + 0x00C)
+#define NPCX_TWMWD(base_addr)                  REG8((base_addr) + 0x00E)
+#define NPCX_WDCP(base_addr)                   REG8((base_addr) + 0x010)
+
+/* TWD register fields */
+#define NPCX_TWCFG_LTWCFG                      0
+#define NPCX_TWCFG_LTWCP                       1
+#define NPCX_TWCFG_LTWDT0                      2
+#define NPCX_TWCFG_LWDCNT                      3
+#define NPCX_TWCFG_WDCT0I                      4
+#define NPCX_TWCFG_WDSDME                      5
+#define NPCX_T0CSR_RST                         0
+#define NPCX_T0CSR_TC                          1
+#define NPCX_T0CSR_WDLTD                       3
+#define NPCX_T0CSR_WDRST_STS                   4
+#define NPCX_T0CSR_WD_RUN                      5
+#define NPCX_T0CSR_TESDIS                      7
+
+/******************************************************************************/
+/* TWD macro functions */
+
+/******************************************************************************/
+/* TWD enumeration */
+
+#endif /* _NPCX_WATCHDOG_H */

--- a/npcx/npcx7/npcx7m6fb.h
+++ b/npcx/npcx7/npcx7m6fb.h
@@ -1,0 +1,172 @@
+/* Copyright 2020 The Chromium OS Authors. All rights reserved.
+ * Use of this source code is governed by a BSD-style license that can be
+ * found in the LICENSE file.
+ */
+
+#ifndef NPCX7M6FB_H
+#define NPCX7M6FB_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "reg_type.h"
+#include "reg_access.h"
+
+/******************************************************************************/
+/*
+ * IRQ Mapping in in NPCX7M6FB soc
+ */
+#define NPCX_IRQ_0                       0
+#define NPCX_IRQ_1                       1
+#define NPCX_IRQ_2                       2
+#define NPCX_IRQ_3                       3
+#define NPCX_IRQ_4                       4
+#define NPCX_IRQ_5                       5
+#define NPCX_IRQ_6                       6
+#define NPCX_IRQ_7                       7
+#define NPCX_IRQ_8                       8
+#define NPCX_IRQ_9                       9
+#define NPCX_IRQ_10                      10
+#define NPCX_IRQ_11                      11
+#define NPCX_IRQ_12                      12
+#define NPCX_IRQ_13                      13
+#define NPCX_IRQ_14                      14
+#define NPCX_IRQ_15                      15
+#define NPCX_IRQ_16                      16
+#define NPCX_IRQ_17                      17
+#define NPCX_IRQ_18                      18
+#define NPCX_IRQ_19                      19
+#define NPCX_IRQ_20                      20
+#define NPCX_IRQ_21                      21
+#define NPCX_IRQ_22                      22
+#define NPCX_IRQ_23                      23
+#define NPCX_IRQ_24                      24
+#define NPCX_IRQ_25                      25
+#define NPCX_IRQ_26                      26
+#define NPCX_IRQ_27                      27
+#define NPCX_IRQ_28                      28
+#define NPCX_IRQ_29                      29
+#define NPCX_IRQ_30                      30
+#define NPCX_IRQ_31                      31
+#define NPCX_IRQ_32                      32
+#define NPCX_IRQ_33                      33
+#define NPCX_IRQ_34                      34
+#define NPCX_IRQ_35                      35
+#define NPCX_IRQ_36                      36
+#define NPCX_IRQ_37                      37
+#define NPCX_IRQ_38                      38
+#define NPCX_IRQ_39                      39
+#define NPCX_IRQ_40                      40
+#define NPCX_IRQ_41                      41
+#define NPCX_IRQ_42                      42
+#define NPCX_IRQ_43                      43
+#define NPCX_IRQ_44                      44
+#define NPCX_IRQ_45                      45
+#define NPCX_IRQ_46                      46
+#define NPCX_IRQ_47                      47
+#define NPCX_IRQ_48                      48
+#define NPCX_IRQ_49                      49
+#define NPCX_IRQ_50                      50
+#define NPCX_IRQ_51                      51
+#define NPCX_IRQ_52                      52
+#define NPCX_IRQ_53                      53
+#define NPCX_IRQ_54                      54
+#define NPCX_IRQ_55                      55
+#define NPCX_IRQ_56                      56
+#define NPCX_IRQ_57                      57
+#define NPCX_IRQ_58                      58
+#define NPCX_IRQ_59                      59
+#define NPCX_IRQ_60                      60
+#define NPCX_IRQ_61                      61
+#define NPCX_IRQ_62                      62
+#define NPCX_IRQ_63                      63
+
+#define NPCX_IRQ0_NOUSED                 NPCX_IRQ_0
+#define NPCX_IRQ1_NOUSED                 NPCX_IRQ_1
+#define NPCX_IRQ_KBSCAN                  NPCX_IRQ_2
+#define NPCX_IRQ_PM_CHAN_OBE             NPCX_IRQ_3
+#define NPCX_IRQ_PECI                    NPCX_IRQ_4
+#define NPCX_IRQ5_NOUSED                 NPCX_IRQ_5
+#define NPCX_IRQ_PORT80                  NPCX_IRQ_6
+#define NPCX_IRQ_MTC_WKINTAD_0           NPCX_IRQ_7
+#define NPCX_IRQ_SMB8                    NPCX_IRQ_8
+#define NPCX_IRQ_MFT_1                   NPCX_IRQ_9
+#define NPCX_IRQ_ADC                     NPCX_IRQ_10
+#define NPCX_IRQ_WKINTEFGH_0             NPCX_IRQ_11
+#define NPCX_IRQ_CDMA                    NPCX_IRQ_12
+#define NPCX_IRQ_SMB1                    NPCX_IRQ_13
+#define NPCX_IRQ_SMB2                    NPCX_IRQ_14
+#define NPCX_IRQ_WKINTC_0                NPCX_IRQ_15
+#define NPCX_IRQ_SMB7                    NPCX_IRQ_16
+#define NPCX_IRQ_ITIM16_3                NPCX_IRQ_17
+#define NPCX_IRQ_SHI                     NPCX_IRQ_18
+#define NPCX_IRQ_ESPI                    NPCX_IRQ_18
+#define NPCX_IRQ_SMB5                    NPCX_IRQ_19
+#define NPCX_IRQ_SMB6                    NPCX_IRQ_20
+#define NPCX_IRQ_PS2                     NPCX_IRQ_21
+#define NPCX_IRQ_WOV                     NPCX_IRQ_22
+#define NPCX_IRQ_MFT_2                   NPCX_IRQ_23
+#define NPCX_IRQ_SHM                     NPCX_IRQ_24
+#define NPCX_IRQ_KBC_IBF                 NPCX_IRQ_25
+#define NPCX_IRQ_PM_CHAN_IBF             NPCX_IRQ_26
+#define NPCX_IRQ_ITIM16_2                NPCX_IRQ_27
+#define NPCX_IRQ_ITIM16_1                NPCX_IRQ_28
+#define NPCX_IRQ29_NOUSED                NPCX_IRQ_29
+#define NPCX_IRQ30_NOUSED                NPCX_IRQ_30
+#define NPCX_IRQ_TWD_WKINTB_0            NPCX_IRQ_31
+#define NPCX_IRQ_UART2                   NPCX_IRQ_32
+#define NPCX_IRQ_UART                    NPCX_IRQ_33
+#define NPCX_IRQ34_NOUSED                NPCX_IRQ_34
+#define NPCX_IRQ35_NOUSED                NPCX_IRQ_35
+#define NPCX_IRQ_SMB3                    NPCX_IRQ_36
+#define NPCX_IRQ_SMB4                    NPCX_IRQ_37
+#define NPCX_IRQ38_NOUSED                NPCX_IRQ_38
+#define NPCX_IRQ39_NOUSED                NPCX_IRQ_39
+#define NPCX_IRQ40_NOUSED                NPCX_IRQ_40
+#define NPCX_IRQ_MFT_3                   NPCX_IRQ_41
+#define NPCX_IRQ42_NOUSED                NPCX_IRQ_42
+#define NPCX_IRQ_ITIM16_4                NPCX_IRQ_43
+#define NPCX_IRQ_ITIM16_5                NPCX_IRQ_44
+#define NPCX_IRQ_ITIM16_6                NPCX_IRQ_45
+#define NPCX_IRQ_ITIM32                  NPCX_IRQ_46
+#define NPCX_IRQ_WKINTA_1                NPCX_IRQ_47
+#define NPCX_IRQ_WKINTB_1                NPCX_IRQ_48
+#define NPCX_IRQ_KSI_WKINTC_1            NPCX_IRQ_49
+#define NPCX_IRQ_WKINTD_1                NPCX_IRQ_50
+#define NPCX_IRQ_WKINTE_1                NPCX_IRQ_51
+#define NPCX_IRQ_WKINTF_1                NPCX_IRQ_52
+#define NPCX_IRQ_WKINTG_1                NPCX_IRQ_53
+#define NPCX_IRQ_WKINTH_1                NPCX_IRQ_54
+#define NPCX_IRQ55_NOUSED                NPCX_IRQ_55
+#define NPCX_IRQ_KBC_OBE                 NPCX_IRQ_56
+#define NPCX_IRQ_SPI                     NPCX_IRQ_57
+#define NPCX_IRQ58_NOUSED                NPCX_IRQ_58
+#define NPCX_IRQ_WKINTFG_2               NPCX_IRQ_59
+#define NPCX_IRQ_WKINTA_2                NPCX_IRQ_60
+#define NPCX_IRQ_WKINTB_2                NPCX_IRQ_61
+#define NPCX_IRQ_WKINTC_2                NPCX_IRQ_62
+#define NPCX_IRQ_WKINTD_2                NPCX_IRQ_63
+
+#define NPCX_IRQ_COUNT                   64
+
+/******************************************************************************/
+/*
+ * Modules Register Definitions in NPCX7M6FB soc
+ */
+#include "modules/adc.h"
+#include "modules/clock.h"
+#include "modules/espi.h"
+#include "modules/gpio.h"
+#include "modules/host.h"
+#include "modules/i2c.h"
+#include "modules/itim.h"
+#include "modules/kbscan.h"
+#include "modules/mft.h"
+#include "modules/miwu.h"
+#include "modules/pwm.h"
+#include "modules/scfg.h"
+#include "modules/uart.h"
+#include "modules/watchdog.h"
+
+#endif /* NPCX7M6FB_H */


### PR DESCRIPTION
Add initial hal drivers for Nuvoton NPCX series which aim to a wide
range of portable applications. The drivers are derived from Chromium
OS Embedded Controller software project
(https://chromium.googlesource.com/chromiumos/platform/ec/) and under
BSP license. Please refer LICENSE file for more information.

Signed-off-by: Mulin Chao <MLChao@nuvoton.com>