### PR TITLE
hal: NuMaker M46x: revise API name of M460 FMC erase bank

### DIFF
--- a/m46x/StdDriver/src/fmc.c
+++ b/m46x/StdDriver/src/fmc.c
@@ -202,7 +202,7 @@ int32_t FMC_Erase(uint32_t u32PageAddr)
   * @note     Global error code g_FMC_i32ErrCode
   *           -1  Erase failed or erase time-out
   */
-int32_t FMC_EraseBank(uint32_t u32BankAddr)
+int32_t FMC_Erase_Bank(uint32_t u32BankAddr)
 {
     int32_t  ret = 0;
     int32_t i32TimeOutCnt;


### PR DESCRIPTION
This PR is to revise M460 API name FMC_EraseBank as FMC_Erase_Bank, to match the declaration in M460 fmc.h header file and also to match the same API name of other Nuvoton BSP, such like as M480 BSP.
More, the owner of external m460BSP/SDK will fix it.