### PR TITLE
hal: NuMaker M46x: modify M460 EMAC driver

### DIFF
--- a/m46x/StdDriver/drv_emac/m460_eth.h
+++ b/m46x/StdDriver/drv_emac/m460_eth.h
@@ -19,7 +19,7 @@
  */
 
 
-#include "M460.h"
+#include "m460.h"
 #ifndef  _M460_ETH_
 #define  _M460_ETH_
 

--- a/m46x/StdDriver/drv_emac/synopGMAC_Dev.c
+++ b/m46x/StdDriver/drv_emac/synopGMAC_Dev.c
@@ -171,6 +171,7 @@ s32 synopGMAC_phy_loopback(synopGMACdevice *gmacdev, bool loopback)
 s32 synopGMAC_read_version (synopGMACdevice * gmacdev)
 {
     u32 data = 0;
+    
     data = synopGMACReadReg((u32 *)gmacdev->MacBase, GmacVersion );
     gmacdev->Version = data;
     TR("The data read from %08x is %08x\n",(gmacdev->MacBase+GmacVersion),data);
@@ -202,7 +203,6 @@ s32 synopGMAC_reset (synopGMACdevice * gmacdev )
 
 s32 synopGMAC_reset_nocheck (synopGMACdevice * gmacdev )
 {
-    u32 data = 0;
     synopGMACWriteReg((u32 *)gmacdev->DmaBase, DmaBusMode ,DmaResetOn);
     plat_delay(DEFAULT_LOOP_VARIABLE);
 
@@ -1648,26 +1648,26 @@ s32 synopGMAC_set_rx_qptr(synopGMACdevice * gmacdev, u32 Buffer1, u32 Length1, u
     if(!synopGMAC_is_desc_empty(rxdesc))
         return -1;
 
-	rxdesc->length |= ((Length1 <<DescSize1Shift) & DescSize1Mask);
+    rxdesc->length |= ((Length1 <<DescSize1Shift) & DescSize1Mask);
 
-	rxdesc->buffer1 = Buffer1;
-	//rxdesc->data1 = Data1;
+    rxdesc->buffer1 = Buffer1;
+    //rxdesc->data1 = Data1;
 
-	rxdesc->extstatus = 0;
-	rxdesc->reserved1 = 0;
-	rxdesc->timestamplow = 0;
-	rxdesc->timestamphigh = 0;
+    rxdesc->extstatus = 0;
+    rxdesc->reserved1 = 0;
+    rxdesc->timestamplow = 0;
+    rxdesc->timestamphigh = 0;
 
-	rxdesc->buffer2 = 0;
-	//rxdesc->data2 = 0;
+    rxdesc->buffer2 = 0;
+    //rxdesc->data2 = 0;
 
-	if((rxnext % MODULO_INTERRUPT) !=0)
-		rxdesc->length |= RxDisIntCompl;
+    if((rxnext % MODULO_INTERRUPT) !=0)
+        rxdesc->length |= RxDisIntCompl;
 
-	rxdesc->status = DescOwnByDma;
+    rxdesc->status = DescOwnByDma;
 
-	gmacdev->RxNext     = synopGMAC_is_last_rx_desc(gmacdev,rxdesc) ? 0 : rxnext + 1;
-	gmacdev->RxNextDesc = synopGMAC_is_last_rx_desc(gmacdev,rxdesc) ? gmacdev->RxDesc : (rxdesc + 1);
+    gmacdev->RxNext     = synopGMAC_is_last_rx_desc(gmacdev,rxdesc) ? 0 : rxnext + 1;
+    gmacdev->RxNextDesc = synopGMAC_is_last_rx_desc(gmacdev,rxdesc) ? gmacdev->RxDesc : (rxdesc + 1);
 
     TR("%02d %08x %08x %08x %08x %08x %08x %08x\n",rxnext,(u32)((u64)rxdesc & 0xFFFFFFFF),rxdesc->status,rxdesc->length,rxdesc->buffer1,rxdesc->buffer2,rxdesc->data1,rxdesc->data2);
 

--- a/m46x/StdDriver/drv_emac/synopGMAC_network_interface.c
+++ b/m46x/StdDriver/drv_emac/synopGMAC_network_interface.c
@@ -152,7 +152,6 @@ s32 synopGMAC_setup_tx_desc_queue(synopGMACdevice * gmacdev,u32 no_of_desc, u32 
     s32 i;
 
     DmaDesc *first_desc = &tx_desc[gmacdev->Intf][0];
-    dma_addr_t dma_addr;
     gmacdev->TxDescCount = 0;
 
 	TR("Total size of memory required for Tx Descriptors in Ring Mode = 0x%08x\n",((sizeof(DmaDesc) * no_of_desc)));
@@ -206,9 +205,7 @@ s32 synopGMAC_setup_tx_desc_queue(synopGMACdevice * gmacdev,u32 no_of_desc, u32 
 s32 synopGMAC_setup_rx_desc_queue(synopGMACdevice * gmacdev,u32 no_of_desc, u32 desc_mode)
 {
     s32 i;
-
     DmaDesc *first_desc = &rx_desc[gmacdev->Intf][0];
-    dma_addr_t dma_addr;
     gmacdev->RxDescCount = 0;
 
 
@@ -236,7 +233,6 @@ s32 synopGMAC_setup_rx_desc_queue(synopGMACdevice * gmacdev,u32 no_of_desc, u32 
 
     return 0;
 }
-
 
 /**
   * This gives up the receive Descriptor queue in ring or chain mode.
@@ -538,7 +534,6 @@ void synopGMAC0_intr_handler(void)
     synopGMACdevice * gmacdev = &GMACdev[0];
     u32 interrupt,dma_status_reg, mac_status_reg;
     s32 status;
-    u32 dma_addr;
 
     // Check GMAC interrupt
     mac_status_reg = synopGMACReadReg((u32 *)gmacdev->MacBase, GmacInterruptStatus);
@@ -616,7 +611,7 @@ void synopGMAC0_intr_handler(void)
 
 
     if(interrupt & synopGMACDmaRxNormal) {
-        u8 **buf
+        u8 **buf = NULL;
     	//printf("rx\n");
         TR("%s:: Rx Normal \n", __FUNCTION__);
         synop_handle_received_data(0, buf);     // Chris, to get RX buffer pointer
@@ -728,10 +723,8 @@ void synopGMAC_set_speed(int intf)
 s32 synopGMAC_open(int intf)
 {
     //s32 status = 0;
-    s32 retval = 0;
     s32 i;
     //s32 reserve_len=2;
-    u32 dma_addr;
     struct sk_buff *skb;
     synopGMACdevice * gmacdev = &GMACdev[intf];
 


### PR DESCRIPTION
This PR is to address compilation warnings of M460 EMAC driver,
 such as unused variables or variables without initial values
 on synopGMAC_Dev.c & synopGMAC_network_interface.c .