### PR TITLE
hal: nuvoton: m55m1: remove smart card header file

### DIFF
--- a/m55m1x/Devices/M55M1/Include/M55M1.h
+++ b/m55m1x/Devices/M55M1/Include/M55M1.h
@@ -1670,7 +1670,6 @@ typedef volatile uint64_t vu64;   ///< Define 64-bit unsigned volatile data type
 #include "qspi.h"
 #include "rng.h"
 #include "rtc.h"
-#include "sc.h"
 #include "scu/scu.h"
 #include "scu/dpm.h"
 #include "scu/plm.h"

--- a/m55m1x/StdDriver/inc/spi.h
+++ b/m55m1x/StdDriver/inc/spi.h
@@ -145,6 +145,25 @@ extern "C"
   */
 #define SPI_CLR_UNIT_TRANS_INT_FLAG(spi)    (spi->STATUS |= SPI_STATUS_UNITIF_Msk)
 
+
+/**
+  * @brief      Disable Slave 3-wire mode.
+  * @param[in]  spi The pointer of the specified SPI module.
+  * @return     None.
+  * @details    Clear SLV3WIRE bit of SPI_SSCTL register to disable Slave 3-wire mode.
+  * \hideinitializer
+  */
+#define SPI_DISABLE_3WIRE_MODE(spi)    (spi->SSCTL &= ~SPI_SSCTL_SLV3WIRE_Msk)
+
+/**
+  * @brief      Enable Slave 3-wire mode.
+  * @param[in]  spi The pointer of the specified SPI module.
+  * @return     None.
+  * @details    Set SLV3WIRE bit of SPI_SSCTL register to enable Slave 3-wire mode.
+  * \hideinitializer
+  */
+#define SPI_ENABLE_3WIRE_MODE(spi)    (spi->SSCTL |= SPI_SSCTL_SLV3WIRE_Msk)
+
 /**
   * @brief      Trigger RX PDMA function.
   * @param[in]  spi The pointer of the specified SPI module.


### PR DESCRIPTION
In current stage, not support smart card. So remove smart card header file to avoid redefined warning in /bluetooth/host/gatt.c.
After applied this PR, [#87025](https://github.com/zephyrproject-rtos/zephyr/pull/87025) could pass all "Run tests with twister / twister-build". 

By the way, add 2 macros in spi.h to support Slave 3-wire mode.