### PR TITLE
hal: nuvoton: m3331: remove llsi and ellsi interfaces

### DIFF
--- a/m333x/Devices/M3331/Include/m3331.h
+++ b/m333x/Devices/M3331/Include/m3331.h
@@ -1238,8 +1238,6 @@ typedef volatile unsigned int   vu32;       ///< Define 32-bit unsigned volatile
 #include "sdh.h"
 #include "hsusbd.h"
 #include "hsotg.h"
-#include "llsi.h"
-#include "ellsi.h"
 #include "cache.h"
 #ifndef __NONSECURE_CODE
 #include "scu.h"


### PR DESCRIPTION
Not support LED light strip and enhanced LED light strip in zephyr. 
More, some define of ellsi.h will cause redefined warning.
So, remove these interfaces.