### PR TITLE
hal: nuvoton: m55m1: update HyperRAM driver to V3.01.003

### DIFF
--- a/m55m1x/StdDriver/inc/spim_hyper.h
+++ b/m55m1x/StdDriver/inc/spim_hyper.h
@@ -39,9 +39,11 @@ extern "C"
 #define SPIM_HYPER_DMM_SIZE                 (0x2000000UL)       /*!< DMM mode memory mapping size */
 
 #define SPIM_HYPER_MAX_LATENCY              (0x20)              /*!< Maximum DLL training number */
+
 /* SPIM_HYPER Define Hyper Device Mode */
 #define SPIM_HYPERRAM_MODE                  (0x01)
 #define SPIM_HYPERFLASH_MODE                (0x02)
+
 #define SPIM_HYPER_OP_ENABLE                (0x01UL)            /* SPIM_HYPER Operation Enable */
 #define SPIM_HYPER_OP_DISABLE               (0x00UL)            /* SPIM_HYPER Operation Disable */
 
@@ -89,14 +91,10 @@ extern "C"
 
 /*----------------------------------------------------------------------------*/
 /* SPIM_HYPER_CONFIG1: Chip Select Hold Time After CK Falling Edge
-    00 = 0.5 HCLK cycles.
-    01 = 1.5 HCLK cycles.
     10 = 2.5 HCLK cycles.
     11 = 3.5 HCLK cycles.
 */
 /*----------------------------------------------------------------------------*/
-#define SPIM_HYPER_CSH_0_5_HCLK    (0x0)
-#define SPIM_HYPER_CSH_1_5_HCLK    (0x1)
 #define SPIM_HYPER_CSH_2_5_HCLK    (0x2)
 #define SPIM_HYPER_CSH_3_5_HCLK    (0x3)
 
@@ -107,20 +105,19 @@ extern "C"
     1111 = 3.5 HCLK cycles.
 */
 /*----------------------------------------------------------------------------*/
-#define SPIM_HYPER_CSHI_2_HCLK    (0x02)
-#define SPIM_HYPER_CSHI_3_HCLK    (0x03)
-#define SPIM_HYPER_CSHI_4_HCLK    (0x04)
-#define SPIM_HYPER_CSHI_5_HCLK    (0x05)
-#define SPIM_HYPER_CSHI_6_HCLK    (0x06)
-#define SPIM_HYPER_CSHI_7_HCLK    (0x07)
-#define SPIM_HYPER_CSHI_8_HCLK    (0x08)
-#define SPIM_HYPER_CSHI_9_HCLK    (0x09)
-#define SPIM_HYPER_CSHI_10_HCLK   (0x0A)
-#define SPIM_HYPER_CSHI_11_HCLK   (0x0B)
-#define SPIM_HYPER_CSHI_12_HCLK   (0x0C)
-#define SPIM_HYPER_CSHI_13_HCLK   (0x0D)
-#define SPIM_HYPER_CSHI_14_HCLK   (0x0E)
-#define SPIM_HYPER_CSHI_15_HCLK   (0x0F)
+#define SPIM_HYPER_CSHI_4_HCLK    (0x03)
+#define SPIM_HYPER_CSHI_5_HCLK    (0x04)
+#define SPIM_HYPER_CSHI_6_HCLK    (0x05)
+#define SPIM_HYPER_CSHI_7_HCLK    (0x06)
+#define SPIM_HYPER_CSHI_8_HCLK    (0x07)
+#define SPIM_HYPER_CSHI_9_HCLK    (0x08)
+#define SPIM_HYPER_CSHI_10_HCLK   (0x09)
+#define SPIM_HYPER_CSHI_11_HCLK   (0x0A)
+#define SPIM_HYPER_CSHI_12_HCLK   (0x0B)
+#define SPIM_HYPER_CSHI_13_HCLK   (0x0C)
+#define SPIM_HYPER_CSHI_14_HCLK   (0x0D)
+#define SPIM_HYPER_CSHI_15_HCLK   (0x0E)
+#define SPIM_HYPER_CSHI_16_HCLK   (0x0F)
 
 /** @} end of group SPIM_HYPER_EXPORTED_CONSTANTS */
 
@@ -131,69 +128,56 @@ extern "C"
 /*  Define Macros and functions                                               */
 /*----------------------------------------------------------------------------*/
 /**
-  * @brief   Get SPIM Cipher Mode.
-  * @param[in]   spim
+  * @brief  Get SPIM Cipher Mode.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_CIPHER(spim) \
     ((spim->CTL0 & SPIM_CTL0_CIPHOFF_Msk) >> SPIM_CTL0_CIPHOFF_Pos)
 
 /**
-  * @brief       Enable Hyper Device Mode.
-  * @param[in]   spim
-  * @param[in]   x   SPIM Hyper Device Mode
-  *                  - \ref SPIM_HYPERRAM_MODE
-  *                  - \ref SPIM_HYPERFLASH_MODE
+  * @brief  Enable Hyper Device Mode.
+  * @param  spim
+  * @param  x SPIM Hyper Device Mode
+  *           - \ref SPIM_HYPERRAM_MODE
+  *           - \ref SPIM_HYPERFLASH_MODE
   * \hideinitializer
   */
-#define SPIM_HYPER_ENABLE_HYPMODE(spim, x)                    \
-    (spim->CTL0 = ((spim->CTL0 & ~(SPIM_CTL0_DEVMODE_Msk)) |  \
-                   ((x) << SPIM_CTL0_DEVMODE_Pos)))
+#define SPIM_HYPER_ENABLE_HYPMODE(spim, x)                        \
+    do {                                                          \
+        (spim->CTL0 = ((spim->CTL0 & ~(SPIM_CTL0_DEVMODE_Msk)) |  \
+                       ((x) << SPIM_CTL0_DEVMODE_Pos)));          \
+        SPIM_HYPER_DISABLE_CIPHER(spim);                          \
+    }while(0)
 
 /**
-  * @brief   Get operation mode.
-  * @param[in]   spim
+  * @brief  Get operation mode.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_OPMODE(spim) \
     ((spim->CTL0 & SPIM_CTL0_OPMODE_Msk) >> SPIM_CTL0_OPMODE_Pos)
 
 /**
-  * @brief   Start operation.
-  * @param[in]   spim
+  * @brief  Start operation.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_GO(spim)   \
     (spim->CTL1 = ((spim->CTL1 & ~(SPIM_CTL1_SPIMEN_Msk)) | SPIM_CTL1_SPIMEN_Msk))
 
 /**
-  * @brief   Is engine busy.
-  * @param[in]   spim
+  * @brief  Is engine busy.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_IS_BUSY(spim)  \
     ((spim->CTL1 & SPIM_CTL1_SPIMEN_Msk) >> SPIM_CTL1_SPIMEN_Pos)
 
 /**
-  * @brief   Is cache enabled.
-  * @param[in]   spim
-  * \hideinitializer
-  */
-#define SPIM_HYPER_GET_CACHE_EN(spim) \
-    ((spim->CTL1 & SPIM_CTL1_CACHEOFF_Msk) >> SPIM_CTL1_CACHEOFF_Pos)
-
-/**
-  * @brief   Invalidate cache.
-  * @param[in]   spim
-  * \hideinitializer
-  */
-#define SPIM_HYPER_INVALID_CACHE(spim)    \
-    (spim->CTL1 = ((spim->CTL1 & ~(SPIM_CTL1_CDINVAL_Msk)) | SPIM_CTL1_CDINVAL_Msk))
-
-/**
-  * @brief   Set SPIM clock divider.
-  * @param[in]   spim
-  * @param[in]   x   Clock Divider Register, only support 1 or 2
+  * @brief  Set SPIM clock divider.
+  * @param  spim
+  * @param  x Clock Divider Register, only support 1 or 2
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_CLKDIV(spim, x)                        \
@@ -201,18 +185,17 @@ extern "C"
                    ((x) << SPIM_CTL1_DIVIDER_Pos)))
 
 /**
-  * @brief   Set SPIM clock divider.
-  * @param[in]   spim
+  * @brief  Set SPIM clock divider.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_CLKDIV(spim) \
     ((spim->CTL1 & SPIM_CTL1_DIVIDER_Msk) >> SPIM_CTL1_DIVIDER_Pos)
 
 /**
-  * @brief   Set DMM mode SPI flash deselect time.
-  * @param[in]   spim
-  * @param[in]   x   DMM mode SPI flash deselect time.
-  *                  It could be 0 ~ 0xFF.
+  * @brief  Set DMM mode SPI flash deselect time.
+  * @param  spim
+  * @param  x DMM mode SPI flash deselect time. It could be 0 ~ 0xFF.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_DMM_DESELTIM(spim, x)                        \
@@ -220,16 +203,16 @@ extern "C"
                      (((x) & 0x1FUL) << SPIM_DMMCTL_DESELTIM_Pos)))
 
 /**
-  * @brief   Get current DMM mode SPI flash deselect time setting.
-  * @param[in]   spim
+  * @brief  Get current DMM mode SPI flash deselect time setting.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DMM_DESELTIM(spim) \
     ((spim->DMMCTL & SPIM_DMMCTL_DESELTIM_Msk) >> SPIM_DMMCTL_DESELTIM_Pos)
 
 /**
-  * @brief   Stop DMM mode Transfer.
-  * @param[in]   spim
+  * @brief  Stop DMM mode Transfer.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_ENABLE_DMMDONE(spim)                             \
@@ -237,75 +220,49 @@ extern "C"
                      SPIM_DMMCTL_HYPDONE_Msk))
 
 /**
-  * @brief   Get DMM mode complete to stop TX/RX.
-  * @param[in]   spim
+  * @brief  Get DMM mode complete to stop TX/RX.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DMMDONE(spim)  \
     ((spim->DMMCTL & SPIM_DMMCTL_HYPDONE_Msk) >> SPIM_DMMCTL_HYPDONE_Pos)
 
 /**
- * @brief   Get DMM idle state.
-* @param[in]   spim
+ * @brief Get DMM idle state.
+ * @param spim
  * \hideinitializer
  */
 #define SPIM_HYPER_GET_DMM_IDLE(spim) \
     ((spim->DMMCTL & SPIM_DMMCTL_DMMIDLE_Msk) >> SPIM_DMMCTL_DMMIDLE_Pos)
 
-/**
- * @brief   Set DMM time-out counter.
- * @param[in]   spim
- * \hideinitializer
- */
-#define SPIM_HYPER_SET_DMM_TOCNTDMM(spim, x)  \
-    (spim->DMM_TIMEOUT_INTERVAL = ((spim->DMM_TIMEOUT_INTERVAL & ~(SPIM_DMM_TIMEOUT_INTERVAL_TOCNTDMM_Msk)) | \
-                                   ((x) <<SPIM_DMM_TIMEOUT_INTERVAL_TOCNTDMM_Pos)))
-
-/**
- * @brief   Get DMM time-out state flag.
- * @param[in]   spim
- * \hideinitializer
- */
-#define SPIM_HYPER_GET_DMM_TIMEOUT_STS(spim)   \
-    ((spim->DMM_TIMEOUT_FLAG_STS & SPIM_DMM_TIMEOUT_FLAG_STS_DMMTOF_Msk) >> SPIM_DMM_TIMEOUT_FLAG_STS_DMMTOF_Pos)
-
-/**
- * @brief   Clear DMM time-out state flag.
- * @param[in]   spim
- * \hideinitializer
- */
-#define SPIM_HYPER_CLR_DMM_TIMEOUT_STS(spim)                                                                \
-    (spim->DMM_TIMEOUT_FLAG_STS = ((spim->DMM_TIMEOUT_FLAG_STS & ~(SPIM_DMM_TIMEOUT_FLAG_STS_DMMTOF_Msk)) | \
-                                   SPIM_DMM_TIMEOUT_FLAG_STS_DMMTOF_Msk))
-
 /*----------------------------------------------------------------------------*/
 /* SPIM_DLLx constant definitions                                            */
 /*----------------------------------------------------------------------------*/
 /**
-  * @brief   Set DLL0 OLDO Enable Bit
-  * @param[in]   spim
-  * @param[in]   x is DLL circuit power mode.
-  *              - \ref SPIM_HYPER_OP_ENABLE
-  *              - \ref SPIM_HYPER_OP_DISABLE
+  * @brief  Set DLL0 OLDO Enable Bit
+  * @param  spim
+  * @param  x is DLL circuit power mode.
+  *           - \ref SPIM_HYPER_OP_ENABLE
+  *           - \ref SPIM_HYPER_OP_DISABLE
   * \hideinitializer
   */
 #define SPIM_HYPER_ENABLE_DLLOLDO(spim, x)  \
     (spim->DLL0 = ((spim->DLL0 & ~(SPIM_DLL0_DLLOLDO_Msk)) | ((x) << SPIM_DLL0_DLLOLDO_Pos)))
 
 /**
-  * @brief   Get DLL0 OLDO Enable Bit
-  * @param[in]   spim
+  * @brief  Get DLL0 OLDO Enable Bit
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLOLDO(spim)  \
     ((spim->DLL0 & SPIM_DLL0_DLLOLDO_Msk) >> SPIM_DLL0_DLLOLDO_Pos)
 
 /**
-  * @brief   Set DLL0 Output Valid Counter Reset.
-  * @param[in]   spim
-  * @param[in]   x is starts to count from 0x0 to DLLOVNUM
-  *              - \ref SPIM_HYPER_OP_ENABLE
-  *              - \ref SPIM_HYPER_OP_DISABLE
+  * @brief  Set DLL0 Output Valid Counter Reset.
+  * @param  spim
+  * @param  x is starts to count from 0x0 to DLLOVNUM
+  *           - \ref SPIM_HYPER_OP_ENABLE
+  *           - \ref SPIM_HYPER_OP_DISABLE
   * \hideinitializer
   */
 #define SPIM_HYPER_ENABLE_DLLOVRST(spim, x)                     \
@@ -313,57 +270,57 @@ extern "C"
                    ((x) << SPIM_DLL0_DLLOVRST_Pos)))
 
 /**
-  * @brief   Get DLL0 Output Valid Counter Reset Done.
-  * @param[in]   spim
+  * @brief  Get DLL0 Output Valid Counter Reset Done.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLOVRST(spim)  \
     ((spim->DLL0 & SPIM_DLL0_DLLOVRST_Msk) >> SPIM_DLL0_DLLOVRST_Pos)
 
 /**
-  * @brief   Get DLL0 Clock Divider Circuit Status Bit.
-  * @param[in]   spim
+  * @brief  Get DLL0 Clock Divider Circuit Status Bit.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLCLKON(spim)  \
     ((spim->DLL0 & SPIM_DLL0_DLLCLKON_Msk) >> SPIM_DLL0_DLLCLKON_Pos)
 
 /**
-  * @brief   Get DLL0 Lock Status Bit.
-  * @param[in]   spim
+  * @brief  Get DLL0 Lock Status Bit.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLLOCK(spim)   \
     ((spim->DLL0 & SPIM_DLL0_DLLLOCK_Msk) >> SPIM_DLL0_DLLLOCK_Pos)
 
 /**
-  * @brief   Get DLL0 Output Ready Status.
-  * @param[in]   spim
+  * @brief  Get DLL0 Output Ready Status.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLREADY(spim)  \
     ((spim->DLL0 & SPIM_DLL0_DLLREADY_Msk) >> SPIM_DLL0_DLLREADY_Pos)
 
 /**
-  * @brief   Get DLL0 Auto Trim Ready Status.
-  * @param[in]   spim
+  * @brief  Get DLL0 Auto Trim Ready Status.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLATRDY(spim)  \
     ((spim->DLL0 & SPIM_DLL0_DLLATRDY_Msk) >> SPIM_DLL0_DLLATRDY_Pos)
 
 /**
-  * @brief   Get DLL0 Refresh Status Bit.
-  * @param[in]   spim
+  * @brief  Get DLL0 Refresh Status Bit.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLREF(spim)    \
     ((spim->DLL0 & SPIM_DLL0_DLL_REF_Msk) >> SPIM_DLL0_DLL_REF_Pos)
 
 /**
-  * @brief   Set DLL0 Delay Step Number.
-  * @param[in]   spim
-  * @param[in]   x   DLL0 Delay Step Number. It could be 0 ~ 0x1F.
+  * @brief  Set DLL0 Delay Step Number.
+  * @param  spim
+  * @param  x DLL0 Delay Step Number. It could be 0 ~ 0x1F.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_DLLDLY_NUM(spim, x)                      \
@@ -371,19 +328,19 @@ extern "C"
                    ((x) << SPIM_DLL0_DLL_DNUM_Pos)))
 
 /**
-  * @brief   Get DLL0 Delay Step Number.
-  * @param[in]   spim
+  * @brief  Get DLL0 Delay Step Number.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLDLY_NUM(spim)    \
     ((spim->DLL0 & SPIM_DLL0_DLL_DNUM_Msk) >> SPIM_DLL0_DLL_DNUM_Pos)
 
 /**
-  * @brief   Set DLL Auto Trim.
-  * @param[in]   spim
-  * @param[in]   x is starts to count from 0x0 to DLLOVNUM
-  *              - \ref SPIM_HYPER_OP_ENABLE
-  *              - \ref SPIM_HYPER_OP_DISABLE
+  * @brief  Set DLL Auto Trim.
+  * @param  spim
+  * @param  x is starts to count from 0x0 to DLLOVNUM
+  *           - \ref SPIM_HYPER_OP_ENABLE
+  *           - \ref SPIM_HYPER_OP_DISABLE
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_AUTO_TRIM_DLL(spim, x)                   \
@@ -391,32 +348,31 @@ extern "C"
                    ((x) << SPIM_DLL0_DLLATEN_Pos)))
 
 /**
-  * @brief   Set HYPERDLL Delay Time Self-Test Enable.
-  * @param[in]   spim
-  * @param[in]   x is starts to count from 0x0 to DLLOVNUM
-  *              - \ref SPIM_HYPER_OP_ENABLE
-  *              - \ref SPIM_HYPER_OP_DISABLE
+  * @brief  Set HYPERDLL Delay Time Self-Test Enable.
+  * @param  spim
+  * @param  x is starts to count from 0x0 to DLLOVNUM
+  *           - \ref SPIM_HYPER_OP_ENABLE
+  *           - \ref SPIM_HYPER_OP_DISABLE
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_DLL_SELF_TEST(spim, x)   \
     (spim->DLL0 = (spim->DLL0 & ~(SPIM_DLL0_DLLLOOP_Msk)) | ((x) << SPIM_DLL0_DLLLOOP_Pos))
 
 /**
-  * @brief   Set Selection for Clock Source DQS/RWDS of HYPERDLL Open Loop Delay Line.
-  * @param[in]   spim
-  * @param[in]   x is starts to count from 0x0 to DLLOVNUM
-  *              - \ref SPIM_HYPER_OP_ENABLE
-  *              - \ref SPIM_HYPER_OP_DISABLE
+  * @brief  Set Selection for Clock Source DQS/RWDS of HYPERDLL Open Loop Delay Line.
+  * @param  spim
+  * @param  x is starts to count from 0x0 to DLLOVNUM
+  *           - \ref SPIM_HYPER_OP_ENABLE
+  *           - \ref SPIM_HYPER_OP_DISABLE
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_INTERNAL_RWDS(spim, x)   \
     (spim->DLL0 = (spim->DLL0 & ~(SPIM_DLL0_SIGINTEN_Msk)) | ((x) << SPIM_DLL0_SIGINTEN_Pos))
 
 /**
-  * @brief   Set DLL0 Delay Step Number.
-  * @param[in]   spim
-  * @param[in]   x   DLL0 Delay Step Number.
-  *                  It could be 0 ~ 0x1F.
+  * @brief  Set DLL0 Delay Step Number.
+  * @param  spim
+  * @param  x DLL0 Delay Step Number. It could be 0 ~ 0x1F.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_DLLDIV(spim, x)                          \
@@ -424,11 +380,11 @@ extern "C"
                    ((x) << SPIM_DLL0_DLLDIVER_Pos)))
 
 /**
- * @brief   Set Band Selection of HYPERDLL Reference Clock.
- * @param[in] spim
- * @param[in] x is selection of HYPERDLL reference clock.
- *            - \ref SPIM_OP_ENABLE
- *            - \ref SPIM_OP_DISABLE
+ * @brief Set Band Selection of HYPERDLL Reference Clock.
+ * @param spim
+ * @param x is selection of HYPERDLL reference clock.
+ *          - \ref SPIM_OP_ENABLE
+ *          - \ref SPIM_OP_DISABLE
  * \hideinitializer
  */
 #define SPIM_HYPER_SET_DLLFAST(spim, x)                         \
@@ -436,10 +392,10 @@ extern "C"
                    ((x) << SPIM_DLL0_DLLFAST_Pos)))
 
 /**
-  * @brief   Set Cycle Number of between DLL Lock and DLL Output Valid.
-  * @param[in]   spim
-  * @param[in]   x   Cycle Number of between DLL Lock and DLL Output Valid.
-  *                  It could be 0 ~ 0xFFFF.
+  * @brief  Set Cycle Number of between DLL Lock and DLL Output Valid.
+  * @param  spim
+  * @param  x Cycle Number of between DLL Lock and DLL Output Valid.
+  *           It could be 0 ~ 0xFFFF.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_DLLOV_NUM(spim, x)                       \
@@ -447,18 +403,18 @@ extern "C"
                    ((x) << SPIM_DLL1_DLLOVNUM_Pos)))
 
 /**
-  * @brief   Get Cycle Number of between DLL Lock and DLL Output Valid.
-  * @param[in]   spim
+  * @brief  Get Cycle Number of between DLL Lock and DLL Output Valid.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLOV_NUM(spim) \
     ((spim->DLL1 & SPIM_DLL1_DLLOVNUM_Msk) >> SPIM_DLL1_DLLOVNUM_Pos)
 
 /**
-  * @brief   Set Cycle Number between DLL Clock Divider Enable and DLL Lock Valid.
-  * @param[in]   spim
-  * @param[in]   x   Cycle Number between DLL Clock Divider Enable and DLL Lock Valid.
-  *                  It could be 0 ~ 0xFFFF.
+  * @brief  Set Cycle Number between DLL Clock Divider Enable and DLL Lock Valid.
+  * @param  spim
+  * @param  x Cycle Number between DLL Clock Divider Enable and DLL Lock Valid.
+  *           It could be 0 ~ 0xFFFF.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_DLLLOCK_NUM(spim, x)                     \
@@ -466,18 +422,18 @@ extern "C"
                    ((x) << SPIM_DLL1_DLLLKNUM_Pos)))
 
 /**
-  * @brief   Get Cycle Number between DLL Clock Divider Enable and DLL Lock Valid.
-  * @param[in]   spim
+  * @brief  Get Cycle Number between DLL Clock Divider Enable and DLL Lock Valid.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_DLLLOCKNUM(spim) \
     ((spim->DLL1 & SPIM_DLL1_DLLLKNUM_Msk) >> SPIM_DLL1_DLLLKNUM_Pos)
 
 /**
-  * @brief   Set Cycle Number of between DLL Output Valid and DLL Auto Trim Enable Time.
-  * @param[in]   spim
-  * @param[in]   x   Cycle Number of between DLL Output Valid and DLL Auto Trim Enable Time.
-  *                  It could be 0 ~ 0xFFFF.
+  * @brief  Set Cycle Number of between DLL Output Valid and DLL Auto Trim Enable Time.
+  * @param  spim
+  * @param  x Cycle Number of between DLL Output Valid and DLL Auto Trim Enable Time.
+  *           It could be 0 ~ 0xFFFF.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_DLLTRIM_NUM(spim, x)                     \
@@ -485,10 +441,10 @@ extern "C"
                    ((x) << SPIM_DLL2_TRIMNUM_Pos)))
 
 /**
-  * @brief   Set Cycle Number of between DLL OLDO Enable and DLL Clock Divider Enable Time.
-  * @param[in]   spim
-  * @param[in]   x   Cycle Number of between DLL OLDO Enable and DLL Clock Divider Enable Time.
-  *                  It could be 0 ~ 0xFFFF.
+  * @brief  Set Cycle Number of between DLL OLDO Enable and DLL Clock Divider Enable Time.
+  * @param  spim
+  * @param  x Cycle Number of between DLL OLDO Enable and DLL Clock Divider Enable Time.
+  *           It could be 0 ~ 0xFFFF.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_DLLCLKON_NUM(spim, x)                    \
@@ -496,78 +452,86 @@ extern "C"
                    ((x) << SPIM_DLL2_CLKONNUM_Pos)))
 
 /**
-  * @brief   Set Hyper Chip Select Setup Time to Next CK Rising Edge.
-  * @param[in]  spim
-  * @param[in]  x   Chip Select Setup Time to Next CK Rising Edge.
-  *                  - \ref SPIM_HYPER_CSST_3_5_HCLK : 3.5 HCLK cycles
-  *                  - \ref SPIM_HYPER_CSST_4_5_HCLK : 4.5 HCLK cycles
+  * @brief  Set Hyper Chip Select Setup Time to Next CK Rising Edge.
+  * @param  spim
+  * @param  x Chip Select Setup Time to Next CK Rising Edge.
+  *           - \ref SPIM_HYPER_CSST_3_5_HCLK : 3.5 HCLK cycles
+  *           - \ref SPIM_HYPER_CSST_4_5_HCLK : 4.5 HCLK cycles
   * \hideinitializer
   */
-#define SPIM_HYPER_SET_CSST(spim, x)                                                \
-    (spim->HYPER_CONFIG1 = ((spim->HYPER_CONFIG1 & ~(SPIM_HYPER_CONFIG1_CSS_Msk)) | \
-                            ((x) << SPIM_HYPER_CONFIG1_CSS_Pos)))
+#define SPIM_HYPER_SET_CSST(spim, x)                                                            \
+    do {                                                                                        \
+        uint32_t _u32CSST = ((x) < SPIM_HYPER_CSST_3_5_HCLK) ? SPIM_HYPER_CSST_3_5_HCLK :       \
+                            ((x) > SPIM_HYPER_CSST_4_5_HCLK) ? SPIM_HYPER_CSST_4_5_HCLK : (x);  \
+        (spim)->HYPER_CONFIG1 = ((spim)->HYPER_CONFIG1 & ~SPIM_HYPER_CONFIG1_CSS_Msk) |         \
+                                ((_u32CSST) << SPIM_HYPER_CONFIG1_CSS_Pos);                     \
+    } while (0)
 
 /**
-  * @brief   Set Hyper Chip Select Hold Time After CK Falling Edge.
-  * @param[in]  spim
-  * @param[in]  x   Chip Select Hold Time After CK Falling Edge.
-  *                 - \ref SPIM_HYPER_CSH_0_5_HCLK : 0.5 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSH_1_5_HCLK : 1.5 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSH_2_5_HCLK : 2.5 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSH_3_5_HCLK : 3.5 HCLK cycles
+  * @brief  Set Hyper Chip Select Hold Time After CK Falling Edge.
+  * @param  spim
+  * @param  x Chip Select Hold Time After CK Falling Edge.
+  *           - \ref SPIM_HYPER_CSH_2_5_HCLK : 2.5 HCLK cycles
+  *           - \ref SPIM_HYPER_CSH_3_5_HCLK : 3.5 HCLK cycles
   * \hideinitializer
   */
-#define SPIM_HYPER_SET_CSH(spim, x)                                                 \
-    (spim->HYPER_CONFIG1 = ((spim->HYPER_CONFIG1 & ~(SPIM_HYPER_CONFIG1_CSH_Msk)) | \
-                            ((x) << SPIM_HYPER_CONFIG1_CSH_Pos)))
+#define SPIM_HYPER_SET_CSH(spim, x)                                                         \
+    do {                                                                                    \
+        uint32_t u32CSH = ((x) < SPIM_HYPER_CSH_2_5_HCLK) ? SPIM_HYPER_CSH_2_5_HCLK :       \
+                          ((x) > SPIM_HYPER_CSH_3_5_HCLK) ? SPIM_HYPER_CSH_3_5_HCLK : (x);  \
+        (spim)->HYPER_CONFIG1 = ((spim)->HYPER_CONFIG1 & ~(SPIM_HYPER_CONFIG1_CSH_Msk)) |   \
+                                (u32CSH << SPIM_HYPER_CONFIG1_CSH_Pos);                     \
+    } while (0)
 
 /**
-  * @brief   Set Hyper Chip Select High between Transaction.
-  * @param[in]  spim
-  * @param[in]  x   Set Chip Select High between Transaction as u8Value HCLK cycles.
-  *                  It could be 2 ~ 16.
-  *                 - \ref SPIM_HYPER_CSHI_2_HCLK  : 2 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_3_HCLK  : 3 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_4_HCLK  : 4 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_5_HCLK  : 5 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_6_HCLK  : 6 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_7_HCLK  : 7 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_8_HCLK  : 8 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_9_HCLK  : 9 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_10_HCLK : 10 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_11_HCLK : 11 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_12_HCLK : 12 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_13_HCLK : 13 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_14_HCLK : 14 HCLK cycles
-  *                 - \ref SPIM_HYPER_CSHI_15_HCLK : 15 HCLK cycles
-  * \hideinitializer
-  */
-#define SPIM_HYPER_SET_CSHI(spim, x)                                                    \
-    (spim->HYPER_CONFIG1 = ((spim->HYPER_CONFIG1 & ~(SPIM_HYPER_CONFIG1_CSHI_Msk)) |    \
-                            ((x) << SPIM_HYPER_CONFIG1_CSHI_Pos)))
+ * @brief Set Hyper Chip Select High between Transaction.
+ * @param spim
+ * @param x   Set Chip Select High between Transaction as u8Value HCLK cycles.
+ *                - \ref SPIM_HYPER_CSHI_4_HCLK  : 4 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_5_HCLK  : 5 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_6_HCLK  : 6 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_7_HCLK  : 7 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_8_HCLK  : 8 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_9_HCLK  : 9 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_10_HCLK : 10 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_11_HCLK : 11 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_12_HCLK : 12 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_13_HCLK : 13 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_14_HCLK : 14 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_15_HCLK : 15 HCLK cycles
+ *                - \ref SPIM_HYPER_CSHI_16_HCLK : 16 HCLK cycles
+ * \hideinitializer
+ */
+#define SPIM_HYPER_SET_CSHI(spim, x)                                                        \
+    do {                                                                                    \
+        uint32_t u32CSHI = ((x) < SPIM_HYPER_CSHI_4_HCLK) ? SPIM_HYPER_CSHI_4_HCLK :        \
+                           ((x) > SPIM_HYPER_CSHI_16_HCLK) ? SPIM_HYPER_CSHI_16_HCLK : (x); \
+        (spim)->HYPER_CONFIG1 = (((spim)->HYPER_CONFIG1 & ~(SPIM_HYPER_CONFIG1_CSHI_Msk)) | \
+                                 ((u32CSHI) << SPIM_HYPER_CONFIG1_CSHI_Pos));               \
+    }while(0)
 
 /**
-  * @brief   Set Hyper Chip Select Maximum Low Time.
-  * @param[in]  spim
-  * @param[in]  u32CsMaxLT  Set Hyper Chip Select Maximum Low Time as u32CsMaxLT HCLK cycles.
-  *                         It could be 1 ~ 2048.
+  * @brief  Set Hyper Chip Select Maximum Low Time.
+  * @param  spim
+  * @param  u32CsMaxLT  Set Hyper Chip Select Maximum Low Time as u32CsMaxLT HCLK cycles.
+  *                     It could be 1 ~ 2048.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_CSMAXLT(spim, u32CsMaxLT)                                        \
     (spim->HYPER_CONFIG1 = ((spim->HYPER_CONFIG1 & ~(SPIM_HYPER_CONFIG1_CSMAXLT_Msk)) | \
                             (((u32CsMaxLT) - 1) << SPIM_HYPER_CONFIG1_CSMAXLT_Pos)))
 /**
-  * @brief   Get Hyper Chip Select Maximum Low Time.
-  * @param[in]   spim
+  * @brief  Get Hyper Chip Select Maximum Low Time.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_CSMAXLT(spim)    \
     (((spim->HYPER_CONFIG1 & SPIM_HYPER_CONFIG1_CSMAXLT_Msk) >> SPIM_HYPER_CONFIG1_CSMAXLT_Pos) + 1UL)
 
 /**
-  * @brief   Set Hyper Chip Initial Read Access Time.
-  * @param[in]  spim
-  * @param[in]  x   Initial Access Time. It could be 1 ~ 31.
+  * @brief  Set Hyper Chip Initial Read Access Time.
+  * @param  spim
+  * @param  x Initial Access Time. It could be 1 ~ 31.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_ACCTWR(spim, x)                                                  \
@@ -575,17 +539,17 @@ extern "C"
                             ((x) << SPIM_HYPER_CONFIG2_ACCTWR_Pos)))
 
 /**
-  * @brief   Get Hyper Chip Initial Read Access Time.
-  * @param[in]   spim
+  * @brief  Get Hyper Chip Initial Read Access Time.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_ACCTWR(spim) \
     ((spim->HYPER_CONFIG2 & SPIM_HYPER_CONFIG2_ACCTWR_Msk) >> SPIM_HYPER_CONFIG2_ACCTWR_Pos)
 
 /**
-  * @brief   Set Hyper Device RESETN Low Time.
-  * @param[in]  spim
-  * @param[in]  x Initial Device RESETN Low Time. It could be 0 ~ 255.
+  * @brief  Set Hyper Device RESETN Low Time.
+  * @param  spim
+  * @param  x Initial Device RESETN Low Time. It could be 0 ~ 255.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_RSTNLT(spim, x)                                                  \
@@ -593,17 +557,17 @@ extern "C"
                             ((x) << SPIM_HYPER_CONFIG2_RSTNLT_Pos)))
 
 /**
-  * @brief   Get Hyper Device RESETN Low Time.
-  * @param[in]   spim
+  * @brief  Get Hyper Device RESETN Low Time.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_RSTNLT(spim) \
     ((spim->HYPER_CONFIG2 & SPIM_HYPER_CONFIG2_RSTNLT_Msk) >> SPIM_HYPER_CONFIG2_RSTNLT_Pos)
 
 /**
-  * @brief   Set Hyper Chip Initial Read Access Time.
-  * @param[in]  spim
-  * @param[in]  x   Initial Access Time. It could be 1 ~ 31.
+  * @brief  Set Hyper Chip Initial Read Access Time.
+  * @param  spim
+  * @param  x Initial Access Time. It could be 1 ~ 31.
   * \hideinitializer
   */
 #define SPIM_HYPER_SET_ACCTRD(spim, x)                                                  \
@@ -611,23 +575,23 @@ extern "C"
                             ((x) << SPIM_HYPER_CONFIG2_ACCTRD_Pos)))
 
 /**
-  * @brief   Get Hyper Chip Initial Read Access Time.
-  * @param[in]   spim
+  * @brief  Get Hyper Chip Initial Read Access Time.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_ACCTRD(spim) \
     ((spim->HYPER_CONFIG2 & SPIM_HYPER_CONFIG2_ACCTRD_Msk) >> SPIM_HYPER_CONFIG2_ACCTRD_Pos)
 
 /**
-  * @brief   Clear Hyper Bus Write DATA
-  * @param[in]   spim
+  * @brief  Clear Hyper Bus Write DATA
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_CLEAR_WDATA(spim)    (spim->HYPER_WDATA &= ~(0xFFFFFFFF))
 
 /**
-  * @brief   Enable Hyper Chip Operation Done Interrupt.
-  * @param[in]   spim
+  * @brief  Enable Hyper Chip Operation Done Interrupt.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_ENABLE_INT(spim)                                               \
@@ -635,23 +599,23 @@ extern "C"
                           SPIM_HYPER_INTEN_OPINTEN_Msk))
 
 /**
-  * @brief   Disable Hyper Chip Operation Done Interrupt.
-  * @param[in]   spim
+  * @brief  Disable Hyper Chip Operation Done Interrupt.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_DISABLE_INT(spim)    (spim->HYPER_INTEN &= ~(SPIM_HYPER_INTEN_OPINTEN_Msk))
 
 /**
-  * @brief   Get Hyper Bus Operation Done Interrupt.
-  * @param[in]   spim
+  * @brief  Get Hyper Bus Operation Done Interrupt.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_INT(spim)    \
     ((spim->HYPER_INTEN & SPIM_HYPER_INTEN_OPINTEN_Msk) >> SPIM_HYPER_INTEN_OPINTEN_Pos)
 
 /**
-  * @brief   Get Hyper Chip Operation Done Interrupt.
-  * @param[in]   spim
+  * @brief  Get Hyper Chip Operation Done Interrupt.
+  * @param  spim
   * \hideinitializer
   */
 #define SPIM_HYPER_GET_INTSTS(spim) \
@@ -663,9 +627,6 @@ extern "C"
 __STATIC_INLINE int32_t SPIM_HYPER_WAIT_DMMDONE(SPIM_T *spim);
 __STATIC_INLINE void SPIM_HYPER_DISABLE_CIPHER(SPIM_T *spim);
 __STATIC_INLINE void SPIM_HYPER_ENABLE_CIPHER(SPIM_T *spim);
-
-__STATIC_INLINE void SPIM_HYPER_DISABLE_CACHE(SPIM_T *spim);
-__STATIC_INLINE void SPIM_HYPER_ENABLE_CACHE(SPIM_T *spim);
 __STATIC_INLINE uint32_t SPIM_HYPER_GET_DMMADDR(SPIM_T *spim);
 __STATIC_INLINE void SPIM_HYPER_SET_OPMODE(SPIM_T *spim, uint32_t x);
 
@@ -678,24 +639,24 @@ __STATIC_INLINE void SPIM_HYPER_SET_OPMODE(SPIM_T *spim, uint32_t x);
   */
 __STATIC_INLINE int32_t SPIM_HYPER_WAIT_DMMDONE(SPIM_T *spim)
 {
-    volatile int32_t u32TimeOutCount = SPIM_HYPER_TIMEOUT;
+    volatile int32_t i32TimeOutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
     SPIM_HYPER_ENABLE_DMMDONE(spim);       /* HyperBus DMM Mode Done.  */
 
     while (SPIM_HYPER_GET_DMMDONE(spim))
     {
-        if (--u32TimeOutCount <= 0)
+        if (--i32TimeOutCount <= 0)
         {
-            return SPIM_HYPER_ERR_TIMEOUT;
+            break;
         }
     }
 
-    u32TimeOutCount = SPIM_HYPER_TIMEOUT;
+    i32TimeOutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
     /* Wait for DMM mode to be idle */
     while (SPIM_HYPER_GET_DMM_IDLE(spim) == SPIM_HYPER_OP_DISABLE)
     {
-        if (--u32TimeOutCount <= 0)
+        if (--i32TimeOutCount <= 0)
         {
             break;
         }
@@ -705,10 +666,9 @@ __STATIC_INLINE int32_t SPIM_HYPER_WAIT_DMMDONE(SPIM_T *spim)
 }
 
 /**
-  * @brief   Disable cipher.
-  * @param[in]   spim
-  * @note    When encryption/decryption of SPIM is disabled,
-  *          please set SPIM_HYPER_SET_DMM_DESELTIM >= 0x8.
+  * @brief  Disable cipher.
+  * @param  spim
+  * @note   When encryption/decryption of SPIM is disabled.
   */
 __STATIC_INLINE void SPIM_HYPER_DISABLE_CIPHER(SPIM_T *spim)
 {
@@ -718,10 +678,9 @@ __STATIC_INLINE void SPIM_HYPER_DISABLE_CIPHER(SPIM_T *spim)
 }
 
 /**
-  * @brief   Enable cipher.
-  * @param[in]   spim
-  * @note    When encryption/decryption of SPIM is enabled,
-  *          please set SPIM_HYPER_SET_DMM_DESELTIM() >= 0x10.
+  * @brief  Enable cipher.
+  * @param  spim
+  * @note   When encryption/decryption of SPIM is enabled.
   */
 __STATIC_INLINE void SPIM_HYPER_ENABLE_CIPHER(SPIM_T *spim)
 {
@@ -731,31 +690,9 @@ __STATIC_INLINE void SPIM_HYPER_ENABLE_CIPHER(SPIM_T *spim)
 }
 
 /**
-  * @brief   Disable cache.
-  * @param[in]   spim
-  * @note    Minimum time width of SPIM_SS
-  *          deselect time = (DESELTIM + 1) * AHB clock cycle time.
-  */
-__STATIC_INLINE void SPIM_HYPER_DISABLE_CACHE(SPIM_T *spim)
-{
-    (spim->CTL1 |= SPIM_CTL1_CACHEOFF_Msk);
-}
-
-/**
-  * @brief   Enable cache.
-  * @param[in]   spim
-  * @note    Minimum time width of SPIM_SS
-  *          deselect time = (DESELTIM + 4) * AHB clock cycle time.
-  */
-__STATIC_INLINE void SPIM_HYPER_ENABLE_CACHE(SPIM_T *spim)
-{
-    (spim->CTL1 &= ~(SPIM_CTL1_CACHEOFF_Msk));
-}
-
-/**
-  * @brief   Get Direct Map Address.
-  * @param[in]  spim
-  * @return Direct Mapping Address
+  * @brief  Get Direct Map Address.
+  * @param  spim
+  * @return Direct Mapping Address.
   */
 __STATIC_INLINE uint32_t SPIM_HYPER_GET_DMMADDR(SPIM_T *spim)
 {
@@ -763,13 +700,13 @@ __STATIC_INLINE uint32_t SPIM_HYPER_GET_DMMADDR(SPIM_T *spim)
 }
 
 /**
-  * @brief       Set operation mode.
-  * @param[in]  spim
-  * @param[in]   x   SPI Function Operation Mode
-  *                  - \ref SPIM_HYPER_OPMODE_IO
-  *                  - \ref SPIM_HYPER_OPMODE_PAGEWRITE
-  *                  - \ref SPIM_HYPER_OPMODE_PAGEREAD
-  *                  - \ref SPIM_HYPER_OPMODE_DIRECTMAP
+  * @brief  Set operation mode.
+  * @param  spim
+  * @param  x SPI Function Operation Mode.
+  *           - \ref SPIM_HYPER_OPMODE_IO
+  *           - \ref SPIM_HYPER_OPMODE_PAGEWRITE
+  *           - \ref SPIM_HYPER_OPMODE_PAGEREAD
+  *           - \ref SPIM_HYPER_OPMODE_DIRECTMAP
   * \hideinitializer
   */
 __STATIC_INLINE void SPIM_HYPER_SET_OPMODE(SPIM_T *spim, uint32_t x)
@@ -793,8 +730,8 @@ int32_t SPIM_HYPER_WriteHyperRAMReg(SPIM_T *spim, uint32_t u32Addr, uint32_t u32
 /* Hyper Device API */
 void SPIM_HYPER_Init(SPIM_T *spim, uint32_t u32HyperMode, uint32_t u32Div);
 int32_t SPIM_HYPER_Reset(SPIM_T *spim);
-int16_t SPIM_HYPER_Read1Word(SPIM_T *spim, uint32_t u32Addr);
-int32_t SPIM_HYPER_Read2Word(SPIM_T *spim, uint32_t u32Addr);
+uint16_t SPIM_HYPER_Read1Word(SPIM_T *spim, uint32_t u32Addr);
+uint32_t SPIM_HYPER_Read2Word(SPIM_T *spim, uint32_t u32Addr);
 int32_t SPIM_HYPER_Write1Byte(SPIM_T *spim, uint32_t u32Addr, uint8_t u8Data);
 int32_t SPIM_HYPER_Write2Byte(SPIM_T *spim, uint32_t u32Addr, uint16_t u16Data);
 int32_t SPIM_HYPER_Write3Byte(SPIM_T *spim, uint32_t u32Addr, uint32_t u32Data);

--- a/m55m1x/StdDriver/src/spim_hyper.c
+++ b/m55m1x/StdDriver/src/spim_hyper.c
@@ -22,7 +22,13 @@
   @{
 */
 
-#define SPIM_HYPER_TRIM_HYPERDLL                (1)
+#ifndef SPIM_HYPER_TRIM_HYPERDLL
+    #define SPIM_HYPER_TRIM_HYPERDLL            (1)
+#endif
+
+#ifndef SPIM_HYPER_MLDOPL0_ADJ_OFFSET
+    #define SPIM_HYPER_MLDOPL0_ADJ_OFFSET       (0)
+#endif
 
 #define SPIM_HYPER_ALTCTL0_DLL0TMEN_Pos         (8)
 #define SPIM_HYPER_ALTCTL0_DLL0TMEN_Msk         (0x1ul << SPIM_HYPER_ALTCTL0_DLL0TMEN_Pos)
@@ -30,40 +36,81 @@
 #define SPIM_HYPER_DLL0ATCTL0_TUDOFF_Pos        (9)
 #define SPIM_HYPER_DLL0ATCTL0_TUDOFF_Msk        (0x1ul << SPIM_HYPER_DLL0ATCTL0_TUDOFF_Pos)
 
-#define SPIM_HYPER_ENABLE_SYSDLL0TMEN() \
-    do{ \
-        uint32_t u32Value = ((inpw(SYS_BASE + 0xE00)) | SPIM_HYPER_ALTCTL0_DLL0TMEN_Msk);\
-        outpw((SYS_BASE + 0xE00), u32Value);\
+#define SPIM_HYPER_MLDOTCTL_MLDOPL0VT_Pos       (0)
+#define SPIM_HYPER_MLDOTCTL_MLDOPL0VT_Msk       (0x3Ful << SPIM_HYPER_MLDOTCTL_MLDOPL0VT_Pos)
+
+#define SPIM_HYPER_MLDOTCTL_WRBUSY_Pos          (31)
+#define SPIM_HYPER_MLDOTCTL_WRBUSY_Msk          (0x1ul << SPIM_HYPER_MLDOTCTL_WRBUSY_Pos)
+
+#define SPIM_HYPER_DLLTCTL_DLL0OLDOTRIM_Pos     (0)
+#define SPIM_HYPER_DLLTCTL_DLL0OLDOTRIM_Msk     (0xFul << SPIM_HYPER_DLLTCTL_DLL0OLDOTRIM_Pos)
+
+#define SPIM_HYPER_ENABLE_SYSDLL0TMEN()                                                     \
+    do{                                                                                     \
+        uint32_t u32Value = ((inpw(SYS_BASE + 0xE00)) | SPIM_HYPER_ALTCTL0_DLL0TMEN_Msk);   \
+        outpw((SYS_BASE + 0xE00), u32Value);                                                \
     }while(0)
 
-#define SPIM_HYPER_DISABLE_SYSDLL0TMEN() \
-    do{ \
-        uint32_t u32Value = ((inpw(SYS_BASE + 0xE00)) & ~SPIM_HYPER_ALTCTL0_DLL0TMEN_Msk);\
-        outpw((SYS_BASE + 0xE00), u32Value);\
+#define SPIM_HYPER_DISABLE_SYSDLL0TMEN()                                                    \
+    do{                                                                                     \
+        uint32_t u32Value = ((inpw(SYS_BASE + 0xE00)) & ~SPIM_HYPER_ALTCTL0_DLL0TMEN_Msk);  \
+        outpw((SYS_BASE + 0xE00), u32Value);                                                                                                \
     }while(0)
 
-#define SPIM_HYPER_ENABLE_SYSDLL0ATCTL0_TRIMUPDOFF()                                \
-    do{ \
-        uint32_t u32Value = ((inpw(SYS_BASE + 0xF84)) & ~SPIM_HYPER_DLL0ATCTL0_TUDOFF_Msk);\
-        outpw((SYS_BASE + 0xF84), u32Value);\
+#define SPIM_HYPER_ENABLE_SYSDLL0ATCTL0_TRIMUPDOFF()                                        \
+    do{                                                                                     \
+        uint32_t u32Value = ((inpw(SYS_BASE + 0xF84)) & ~SPIM_HYPER_DLL0ATCTL0_TUDOFF_Msk); \
+        outpw((SYS_BASE + 0xF84), u32Value); \
     }while(0)
 
-#define SPIM_HYPER_DISABLE_SYSDLL0ATCTL0_TRIMUPDOFF()                                \
-    do{ \
-        uint32_t u32Value = ((inpw(SYS_BASE + 0xF84)) | SPIM_HYPER_DLL0ATCTL0_TUDOFF_Msk);\
-        outpw((SYS_BASE + 0xF84), u32Value);\
+#define SPIM_HYPER_DISABLE_SYSDLL0ATCTL0_TRIMUPDOFF()                                       \
+    do{                                                                                     \
+        uint32_t u32Value = ((inpw(SYS_BASE + 0xF84)) | SPIM_HYPER_DLL0ATCTL0_TUDOFF_Msk);  \
+        outpw((SYS_BASE + 0xF84), u32Value);                                                \
     }while(0)
 
+#define SPIM_HYPER_GET_MLDOTCTL_MLDOPL0VT() \
+    (((inpw(SYS_BASE + 0xF54)) & SPIM_HYPER_MLDOTCTL_MLDOPL0VT_Msk) >> SPIM_HYPER_MLDOTCTL_MLDOPL0VT_Pos)
+
+#define SPIM_HYPER_SET_MLDOTCTL_MLDOPL0VT(x)                                                  \
+    do{                                                                                       \
+        uint32_t u32Value = ((inpw(SYS_BASE + 0xF54)) & ~SPIM_HYPER_MLDOTCTL_MLDOPL0VT_Msk) | \
+                            ((x) << SPIM_HYPER_MLDOTCTL_MLDOPL0VT_Pos);                       \
+        outpw((SYS_BASE + 0xF54), u32Value);                                                  \
+    }while(0)
+
+#define SPIM_HYPER_GET_MLDOTCTL_WRBUSY()    \
+    (((inpw(SYS_BASE + 0xF54)) & SPIM_HYPER_MLDOTCTL_WRBUSY_Msk) >> SPIM_HYPER_MLDOTCTL_WRBUSY_Pos)
+
+#define SPIM_HYPER_GET_DLLTCTL_DLL0OLDOTRIM()   \
+    (((inpw(SYS_BASE + 0xF80)) & SPIM_HYPER_DLLTCTL_DLL0OLDOTRIM_Msk) >> SPIM_HYPER_DLLTCTL_DLL0OLDOTRIM_Pos)
+
+#define SPIM_HYPER_SET_DLLTCTL_DLL0OLDOTRIM(x)                                                  \
+    do {                                                                                        \
+        uint32_t u32Value = ((inpw(SYS_BASE + 0xF80)) & ~SPIM_HYPER_DLLTCTL_DLL0OLDOTRIM_Msk) | \
+                            ((x) << SPIM_HYPER_DLLTCTL_DLL0OLDOTRIM_Pos);                       \
+        outpw((SYS_BASE + 0xF80), u32Value);                                                    \
+    } while (0)
+
+#define SPIM_HYPER_MLDOPL0_TRIM_OFFSET          (3U)
+#define SPIM_HYPER_DLLTCTL_TRIM_OFFSET          (5U)
+
+#define SPIM_HYPER_CEIL_DIV(x, y)               (((x) + (y) - 1) / (y))
+
+// Timing margin in permille (1000 = 100%). Set to 1100 to apply a +10% safety margin.
+#define SPIM_HYPER_TRIM_MARGIN                  (1000)
+
+//------------------------------------------------------------------------------
 /**
   * @brief      Wait Hyper Bus interface Idle
-  * @param      spim     Specify SPIM peripheral
-  * @retval     SPIM_HYPER_OK          SPIM operation OK.
-  *             SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  * @param      spim    Pointer to the SPIM peripheral.
+  * @retval     SPIM_HYPER_OK          Operation completed successfully.
+  *             SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @details    This function is used to wait Hyper Bus interface idle.
   */
 static int32_t spim_hyper_wait_cmdidle(SPIM_T *spim)
 {
-    volatile int32_t i32TimeOutCnt = SPIM_HYPER_TIMEOUT;
+    volatile int32_t i32TimeOutCnt = (int32_t)SPIM_HYPER_TIMEOUT;
 
     while (spim->HYPER_CMD != SPIM_HYPER_CMD_IDLE)
     {
@@ -76,9 +123,73 @@ static int32_t spim_hyper_wait_cmdidle(SPIM_T *spim)
     return SPIM_HYPER_OK;
 }
 
+#if (SPIM_HYPER_MLDOPL0_ADJ_OFFSET == 1)
+
+/**
+  * @brief      Adjust Power Level for Hyper Bus
+  * @retval     None.
+  * @details    This function is used to adjust the power level for Hyper Bus.
+  *             It raises the MLDOPL0 voltage level to enhance signal integrity and stability.
+  */
+static void SPIM_HYPER_AdjustPowerLevelForHyperBus(void)
+{
+    volatile int32_t i32TimeOutCnt = (SystemCoreClock >> 1); /* 500ms time-out */
+    uint32_t u32MLDOPL0 = 0;
+    uint32_t u32RegLockLevel = SYS_IsRegLocked();
+
+    if (u32RegLockLevel)
+    {
+        /* Unlock protected registers */
+        SYS_UnlockReg();
+    }
+
+    /*
+        Raise PL0 voltage level (MLDOPL0) by predefined offset to reach ~ 1.2V,
+        enhancing HyperBus signal integrity and stability under high-speed access.
+    */
+    u32MLDOPL0 = (SPIM_HYPER_GET_MLDOTCTL_MLDOPL0VT() + SPIM_HYPER_MLDOPL0_TRIM_OFFSET);
+    SPIM_HYPER_SET_MLDOTCTL_MLDOPL0VT(u32MLDOPL0);
+
+    i32TimeOutCnt = (SystemCoreClock >> 1);
+
+    /*
+        Wait until the MLDOTCTL_WRBUSY flag is cleared,
+        indicating that the operation is complete
+    */
+    while (SPIM_HYPER_GET_MLDOTCTL_WRBUSY() == SPIM_OP_ENABLE)
+        if (i32TimeOutCnt-- <= 0) break;
+
+    i32TimeOutCnt = (SystemCoreClock >> 1);
+
+    /* Wait for power level change busy flag is cleared */
+    while (*(volatile uint32_t *)PMC_PLCTL_BUSY_FLAG & BIT31)
+        if (i32TimeOutCnt-- <= 0) break;
+
+    /* Set power voltage level 0 */
+    PMC->PLCTL = (PMC->PLCTL & (~PMC_PLCTL_PLSEL_Msk)) | (PMC_PLCTL_PLSEL_PL0);
+
+    i32TimeOutCnt = (SystemCoreClock >> 1);
+
+    /* Wait for power level change busy flag is cleared */
+    while (*(volatile uint32_t *)PMC_PLCTL_BUSY_FLAG & BIT31)
+        if (i32TimeOutCnt-- <= 0) break;
+
+    /* Increase DLL0 output voltage by predefined offset to reach ~1.2V for better timing margin */
+    u32MLDOPL0 = (SPIM_HYPER_GET_DLLTCTL_DLL0OLDOTRIM() + SPIM_HYPER_DLLTCTL_TRIM_OFFSET);
+    SPIM_HYPER_SET_DLLTCTL_DLL0OLDOTRIM(u32MLDOPL0);
+
+    if (u32RegLockLevel)
+    {
+        /* Lock protected registers */
+        SYS_LockReg();
+    }
+}
+
+#endif
+
 /**
   * @brief      Enable Hyper Bus Mode
-  * @param      spim         Specify SPIM peripheral
+  * @param      spim         Pointer to the SPIM peripheral.
   * @param[in]  u32HyperMode Select HyperRAM or HyperFlash Device
   *                         - \ref SPIM_HYPERRAM_MODE
   *                         - \ref SPIM_HYPERFLASH_MODE
@@ -88,22 +199,28 @@ static int32_t spim_hyper_wait_cmdidle(SPIM_T *spim)
   */
 void SPIM_HYPER_Init(SPIM_T *spim, uint32_t u32HyperMode, uint32_t u32Div)
 {
+#if (SPIM_HYPER_MLDOPL0_ADJ_OFFSET == 1)
+    /* Adjusts the power level for the HyperBus interface. */
+    SPIM_HYPER_AdjustPowerLevelForHyperBus();
+#endif
+
     /* Enable SPIM Hyper Bus Mode */
     SPIM_HYPER_ENABLE_HYPMODE(spim, u32HyperMode);
 
+    /* Sets the clock divider for the SPIM hyper interface. */
     SPIM_HYPER_SET_CLKDIV(spim, (((u32Div != 1) && (u32Div != 2)) ? 1 : u32Div));
 }
 
 /**
   * @brief      SPIM Start Transfer And Wait Busy Status.
-  * @param      spim
+  * @param      spim        Pointer to the SPIM peripheral.
   * @param      u32IsSync   Wait Busy Status
   * @return     SPIM_HYPER_OK          SPIM write done.
-  *             SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  *             SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   */
 int32_t SPIM_HYPER_WaitSPIMENDone(SPIM_T *spim, uint32_t u32IsSync)
 {
-    volatile int32_t i32TimeOutCount = SPIM_HYPER_TIMEOUT;
+    volatile int32_t i32TimeOutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
     /* Start SPIM Transfer, wait for operation complete according to u32IsSync */
     SPIM_HYPER_SET_GO(spim);
@@ -124,9 +241,9 @@ int32_t SPIM_HYPER_WaitSPIMENDone(SPIM_T *spim, uint32_t u32IsSync)
 
 /**
   * @brief  Reset hyper chip function
-  * @param  spim
-  * @return SPIM_HYPER_OK          SPIM operation OK.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  * @param  spim    Pointer to the SPIM peripheral.
+  * @return SPIM_HYPER_OK          Operation completed successfully.
+  *         SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @note   if waiting Hyper Chip time-out.
   */
 int32_t SPIM_HYPER_Reset(SPIM_T *spim)
@@ -146,9 +263,9 @@ int32_t SPIM_HYPER_Reset(SPIM_T *spim)
 
 /**
   * @brief  Exit from Hybrid sleep and deep Power down function
-  * @param  spim
-  * @return SPIM_HYPER_OK          SPIM operation OK.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  * @param  spim    Pointer to the SPIM peripheral.
+  * @return SPIM_HYPER_OK          Operation completed successfully.
+  *         SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT, if waiting Hyper Chip time-out.
   */
 int32_t SPIM_HYPER_ExitHSAndDPD(SPIM_T *spim)
@@ -160,15 +277,15 @@ int32_t SPIM_HYPER_ExitHSAndDPD(SPIM_T *spim)
 
 /**
   * @brief  Read hyper chip register space
-  * @param  spim
+  * @param  spim    Pointer to the SPIM peripheral.
   * @param  u32Addr Address of hyper chip register space
   *                 - \ref SPIM_HYPER_HRAM_ID_REG0       : 0x0000_0000 = Identification Register 0
   *                 - \ref SPIM_HYPER_HRAM_ID_REG1       : 0x0000_0002 = Identification Register 1
   *                 - \ref SPIM_HYPER_HRAM_CONFIG_REG0   : 0x0000_1000 = Configuration Register 0
   *                 - \ref SPIM_HYPER_HRAM_CONFIG_REG1   : 0x0000_1002 = Configuration Register 1
-  * @return SPIM_HYPER_OK          SPIM operation OK.
+  * @return SPIM_HYPER_OK          Operation completed successfully.
   *         SPIM_HYPER_ERR_FAIL    SPIM operation Fail.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  *         SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT, if waiting Hyper Chip time-out.
   */
 int32_t SPIM_HYPER_ReadHyperRAMReg(SPIM_T *spim, uint32_t u32Addr)
@@ -192,16 +309,16 @@ int32_t SPIM_HYPER_ReadHyperRAMReg(SPIM_T *spim, uint32_t u32Addr)
 
 /**
   * @brief  Write Hyper Chip register space
-  * @param  spim
+  * @param  spim    Pointer to the SPIM peripheral.
   * @param  u32Addr Address of Hyper Chip register space
   *                 - \ref SPIM_HYPER_HRAM_ID_REG0     : 0x0000_0000 = Identification Register 0
   *                 - \ref SPIM_HYPER_HRAM_ID_REG1     : 0x0000_0002 = Identification Register 1
   *                 - \ref SPIM_HYPER_HRAM_CONFIG_REG0 : 0x0000_1000 = Configuration Register 0
   *                 - \ref SPIM_HYPER_HRAM_CONFIG_REG1 : 0x0000_1002 = Configuration Register 1
   * @param  u32Value Configure HyperRAM Register Value
-  * @return SPIM_HYPER_OK      SPIM operation OK.
+  * @return SPIM_HYPER_OK      Operation completed successfully.
   *         SPIM_HYPER_ERR_FAIL    SPIM operation Fail.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  *         SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT, if waiting Hyper Chip time-out.
   */
 int32_t SPIM_HYPER_WriteHyperRAMReg(SPIM_T *spim, uint32_t u32Addr, uint32_t u32Value)
@@ -228,12 +345,12 @@ int32_t SPIM_HYPER_WriteHyperRAMReg(SPIM_T *spim, uint32_t u32Addr, uint32_t u32
 
 /**
   * @brief  Read 1 word from hyper chip space
-  * @param  spim
-  * @param  u32Addr  Address of hyper chip space
+  * @param  spim    Pointer to the SPIM peripheral.
+  * @param  u32Addr Address of hyper chip space
   * @return The 16 bit data of hyper chip space.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT if waiting Hyper Chip time-out.
   */
-int16_t SPIM_HYPER_Read1Word(SPIM_T *spim, uint32_t u32Addr)
+uint16_t SPIM_HYPER_Read1Word(SPIM_T *spim, uint32_t u32Addr)
 {
     spim->HYPER_ADR = u32Addr;
 
@@ -241,16 +358,16 @@ int16_t SPIM_HYPER_Read1Word(SPIM_T *spim, uint32_t u32Addr)
 
     spim_hyper_wait_cmdidle(spim);
 
-    return (spim->HYPER_RDATA & 0xFFFF);
+    return (uint16_t)(spim->HYPER_RDATA & 0xFFFF);
 }
 
 /**
   * @brief  Read 2 word from hyper chip space
-  * @param  spim
-  * @param  u32Addr  Address of hyper chip space
+  * @param  spim    Pointer to the SPIM peripheral.
+  * @param  u32Addr Address of hyper chip space
   * @return The 32bit data of hyper chip space.
   */
-int32_t SPIM_HYPER_Read2Word(SPIM_T *spim, uint32_t u32Addr)
+uint32_t SPIM_HYPER_Read2Word(SPIM_T *spim, uint32_t u32Addr)
 {
     spim->HYPER_ADR = u32Addr;
 
@@ -258,16 +375,16 @@ int32_t SPIM_HYPER_Read2Word(SPIM_T *spim, uint32_t u32Addr)
 
     spim_hyper_wait_cmdidle(spim);
 
-    return (spim->HYPER_RDATA & 0xFFFFFFFF);
+    return (uint32_t)(spim->HYPER_RDATA & 0xFFFFFFFF);
 }
 
 /**
   * @brief  Write 1 byte to hyper chip space
-  * @param  spim
-  * @param  u32Addr  Address of hyper chip space
-  * @param  u8Data   8 bits data to be written to hyper chip space
-  * @return SPIM_HYPER_OK      SPIM operation OK.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  * @param  spim    Pointer to the SPIM peripheral.
+  * @param  u32Addr Address of hyper chip space
+  * @param  u8Data  8 bits data to be written to hyper chip space
+  * @return SPIM_HYPER_OK      Operation completed successfully.
+  *         SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT, if waiting Hyper Chip time-out.
   */
 int32_t SPIM_HYPER_Write1Byte(SPIM_T *spim, uint32_t u32Addr, uint8_t u8Data)
@@ -284,11 +401,11 @@ int32_t SPIM_HYPER_Write1Byte(SPIM_T *spim, uint32_t u32Addr, uint8_t u8Data)
 
 /**
   * @brief  Write 2 bytes to Hyper Chip space
-  * @param  spim
-  * @param  u32Addr  Address of Hyper Chip space
-  * @param  u16Data  16 bits data to be written to Hyper Chip space
-  * @return SPIM_HYPER_OK          SPIM operation OK.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  * @param  spim    Pointer to the SPIM peripheral.
+  * @param  u32Addr Address of Hyper Chip space
+  * @param  u16Data 16 bits data to be written to Hyper Chip space
+  * @return SPIM_HYPER_OK          Operation completed successfully.
+  *         SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT, if waiting Hyper Chip time-out.
   */
 int32_t SPIM_HYPER_Write2Byte(SPIM_T *spim, uint32_t u32Addr, uint16_t u16Data)
@@ -305,11 +422,11 @@ int32_t SPIM_HYPER_Write2Byte(SPIM_T *spim, uint32_t u32Addr, uint16_t u16Data)
 
 /**
   * @brief  Write 3 bytes to Hyper Chip space
-  * @param  spim
-  * @param  u32Addr  Address of Hyper Chip space
-  * @param  u32Data  24 bits data to be written to Hyper Chip space
-  * @return SPIM_HYPER_OK          SPIM operation OK.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  * @param  spim    Pointer to the SPIM peripheral.
+  * @param  u32Addr Address of Hyper Chip space
+  * @param  u32Data 24 bits data to be written to Hyper Chip space
+  * @return SPIM_HYPER_OK          Operation completed successfully.
+  *         SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT, if waiting Hyper Chip time-out.
   */
 int32_t SPIM_HYPER_Write3Byte(SPIM_T *spim, uint32_t u32Addr, uint32_t u32Data)
@@ -326,11 +443,11 @@ int32_t SPIM_HYPER_Write3Byte(SPIM_T *spim, uint32_t u32Addr, uint32_t u32Data)
 
 /**
   * @brief  Write 4 byte to hyper chip space
-  * @param  spim
-  * @param  u32Addr  Address of hyper chip space
-  * @param  u32Data  32 bits data to be written to hyper chip space
-  * @return SPIM_HYPER_OK          SPIM operation OK.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  * @param  spim    Pointer to the SPIM peripheral.
+  * @param  u32Addr Address of hyper chip space
+  * @param  u32Data 32 bits data to be written to hyper chip space
+  * @return SPIM_HYPER_OK          Operation completed successfully.
+  *         SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT, if waiting Hyper Chip time-out.
   */
 int32_t SPIM_HYPER_Write4Byte(SPIM_T *spim, uint32_t u32Addr, uint32_t u32Data)
@@ -346,61 +463,62 @@ int32_t SPIM_HYPER_Write4Byte(SPIM_T *spim, uint32_t u32Addr, uint32_t u32Data)
 }
 
 /**
-  * @brief  Write data to HyperBus Module.
-  * @param  spim
-  * @param  u32Addr     Start address to write.
-  * @param  pu8WrBuf    Transmit buffer.
+  * @brief  Write data to the HyperBus module using DMA.
+  * @param  spim        Pointer to the SPIM peripheral.
+  * @param  u32Addr     Start address to write to (HyperBus address).
+  * @param  pu8WrBuf    Pointer to the transmit buffer.
   * @param  u32NTx      Number of bytes to write.
-  * @return SPIM_HYPER_OK          SPIM operation OK.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
-  * @note   This function sets SPIM_HYPER_ERR_TIMEOUT, if waiting Hyper Chip time-out.
+  * @return SPIM_HYPER_OK           Operation completed successfully.
+  *         SPIM_HYPER_ERR_TIMEOUT  Operation aborted due to timeout error.
+  * @note   This function returns SPIM_HYPER_ERR_TIMEOUT if the HyperBus device times out.
+  *         The number of bytes to write must be a multiple of 8 (for DMA alignment).
   */
 int32_t SPIM_HYPER_DMAWrite(SPIM_T *spim, uint32_t u32Addr, uint8_t *pu8WrBuf, uint32_t u32NTx)
 {
-    SPIM_HYPER_SET_OPMODE(spim, SPIM_HYPER_OPMODE_PAGEWRITE);  /* Switch to DMA Write mode.   */
+    SPIM_HYPER_SET_OPMODE(spim, SPIM_HYPER_OPMODE_PAGEWRITE);  /* Switch to DMA write mode. */
 
-    spim->SRAMADDR = (uint32_t) pu8WrBuf;
-    spim->DMACNT = u32NTx;
-    spim->FADDR = u32Addr;
+    spim->SRAMADDR = (uint32_t)pu8WrBuf;  /* Set the SRAM buffer address. */
+    spim->DMACNT   = u32NTx;              /* Set the transfer length. */
+    spim->FADDR    = u32Addr;             /* Set the HyperBus target address. */
 
     return SPIM_HYPER_WaitSPIMENDone(spim, SPIM_HYPER_OP_ENABLE);
 }
 
 /**
-  * @brief  Read data from HyperBus Module.
-  * @param  spim
-  * @param  u32Addr     Start address to read.
-  * @param  pu8RdBuf    Receive buffer.
+  * @brief  Read data from the HyperBus module using DMA.
+  * @param  spim        Pointer to the SPIM peripheral.
+  * @param  u32Addr     Start address to read from (HyperBus address).
+  * @param  pu8RdBuf    Pointer to the receive buffer.
   * @param  u32NRx      Number of bytes to read.
-  * @return SPIM_HYPER_OK          SPIM operation OK.
-  *         SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
-  * @note   This function sets SPIM_HYPER_ERR_TIMEOUT, if waiting Hyper Chip time-out.
+  * @return SPIM_HYPER_OK           Operation completed successfully.
+  *         SPIM_HYPER_ERR_TIMEOUT  Operation aborted due to timeout error.
+  * @note   This function returns SPIM_HYPER_ERR_TIMEOUT if the HyperBus device times out.
+  *         The number of bytes to read must be a multiple of 8 (for DMA alignment).
   */
 int32_t SPIM_HYPER_DMARead(SPIM_T *spim, uint32_t u32Addr, uint8_t *pu8RdBuf, uint32_t u32NRx)
 {
-    SPIM_HYPER_SET_OPMODE(spim, SPIM_HYPER_OPMODE_PAGEREAD);   /* Switch to DMA Read mode.  */
-    spim->SRAMADDR = (uint32_t) pu8RdBuf;               /* SRAM u32Address. */
-    spim->DMACNT = u32NRx;                              /* Transfer length. */
-    spim->FADDR = u32Addr;                              /* Flash u32Address. */
+    SPIM_HYPER_SET_OPMODE(spim, SPIM_HYPER_OPMODE_PAGEREAD);  /* Switch to DMA read mode. */
+    spim->SRAMADDR = (uint32_t)pu8RdBuf;                      /* Set the SRAM buffer address. */
+    spim->DMACNT   = u32NRx;                                  /* Set the transfer length. */
+    spim->FADDR    = u32Addr;                                 /* Set the HyperBus target address. */
 
     return SPIM_HYPER_WaitSPIMENDone(spim, SPIM_HYPER_OP_ENABLE);
 }
 
 /**
   * @brief  SPIM Hyper Mode Enter DMM Mode
-  * @param  spim
+  * @param  spim    Pointer to the SPIM peripheral.
   * @return None.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT if waiting Hyper Chip time-out.
   */
 void SPIM_HYPER_EnterDirectMapMode(SPIM_T *spim)
 {
-    SPIM_HYPER_CLR_DMM_TIMEOUT_STS(spim);
     SPIM_HYPER_SET_OPMODE(spim, SPIM_HYPER_OPMODE_DIRECTMAP);  /* Switch to DMA Write mode.   */
 }
 
 /**
   * @brief  SPIM Hyper Mode Exit DMM Mode
-  * @param  spim
+  * @param  spim    Pointer to the SPIM peripheral.
   * @return None.
   * @note   This function sets SPIM_HYPER_ERR_TIMEOUT if waiting Hyper Chip time-out.
   */
@@ -411,162 +529,143 @@ void SPIM_HYPER_ExitDirectMapMode(SPIM_T *spim)
 
 /**
   * @brief      Initialize SPIM Hyper DLL.
-  * @param      spim     SPIM port handler
-  * @retval     SPIM_HYPER_OK          SPIM operation OK.
-  *             SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  * @param      spim    Pointer to the SPIM peripheral.
+  * @return     SPIM_HYPER_OK          Operation completed successfully.
+  *             SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @details    This function is used to initialize SPIM Hyper bus DLL.
   * @note       When system wake up reset, please calling this function reinintialize DLL.
   */
 int32_t SPIM_HYPER_INIT_DLL(SPIM_T *spim)
 {
-    volatile int i32TimeoutCount = SPIM_HYPER_TIMEOUT;
-    uint32_t u32Div = SPIM_HYPER_GET_CLKDIV(spim);
-    uint32_t u32FastEn = ((((CLK_GetSCLKFreq() / 1000000) / (SPIM_HYPER_GET_CLKDIV(spim) * 2)) <= 100) ? SPIM_HYPER_OP_DISABLE : SPIM_HYPER_OP_ENABLE);
+    volatile int32_t i32TimeoutCount;
+    uint32_t u32BusClkHz = CLK_GetSCLKFreq() / (SPIM_HYPER_GET_CLKDIV(spim) * 2);
+    uint32_t u32ClkNs = 1000000000UL / u32BusClkHz;
+    uint32_t u32DelayCycleCount = 0;
+    const uint32_t u32DllLockUs  = 20;
+    const uint32_t u32DllValidUs = 50;
+    const uint32_t u32DllClkOnUs = 20;
+    const uint32_t u32DllTrimUs  = 20;
 
+    // Convert to cycles
+    uint32_t u32DLLLKNUM = SPIM_HYPER_CEIL_DIV((u32DllLockUs * SPIM_HYPER_TRIM_MARGIN), u32ClkNs);
+    uint32_t u32DLLOVNUM = SPIM_HYPER_CEIL_DIV((u32DllValidUs * SPIM_HYPER_TRIM_MARGIN), u32ClkNs);
+    uint32_t u32CLKONNUM = SPIM_HYPER_CEIL_DIV((u32DllClkOnUs * SPIM_HYPER_TRIM_MARGIN), u32ClkNs);
+    uint32_t u32TRIMNUM  = SPIM_HYPER_CEIL_DIV((u32DllTrimUs * SPIM_HYPER_TRIM_MARGIN), u32ClkNs);
+
+    uint32_t u32Div = (SPIM_HYPER_GET_CLKDIV(spim) * 2);
+    uint32_t u32FreqMHz = u32BusClkHz / 1000000;
+    uint32_t u32FastEn = (u32FreqMHz <= 100) ? SPIM_HYPER_OP_DISABLE : SPIM_HYPER_OP_ENABLE;
+
+    uint32_t u32DllDivCode = (u32Div <= 1) ? 0 : (u32Div == 2) ? 1 : (u32Div == 4) ? 2 : 3;
     uint32_t u32RegLockLevel = SYS_IsRegLocked();
 
-    if (u32RegLockLevel)
-    {
-        /* Unlock protected registers */
-        SYS_UnlockReg();
-    }
+    if (u32RegLockLevel) SYS_UnlockReg();
+
+    // DLL timing setup
+    SPIM_HYPER_SET_DLLLOCK_NUM(spim, u32DLLLKNUM);
+    SPIM_HYPER_SET_DLLOV_NUM(spim, u32DLLOVNUM);
+    SPIM_HYPER_SET_DLLCLKON_NUM(spim, u32CLKONNUM);
+    SPIM_HYPER_SET_DLLTRIM_NUM(spim, u32TRIMNUM);
 
 #if (SPIM_HYPER_TRIM_HYPERDLL == 1)
     SPIM_HYPER_ENABLE_SYSDLL0ATCTL0_TRIMUPDOFF();
 #endif
 
-    SPIM_HYPER_SET_DLLDIV(spim, ((u32Div > 3) ? 3 : u32Div));
-
+    SPIM_HYPER_SET_DLLDIV(spim, u32DllDivCode);
     SPIM_HYPER_SET_DLLFAST(spim, u32FastEn);
-
-    /* SPIM starts to send DLL reference clock to DLL circuit
-    that the frequency is the same as the SPIM output bus clock. */
     SPIM_HYPER_ENABLE_DLLOLDO(spim, SPIM_HYPER_OP_ENABLE);
 
 #if (SPIM_HYPER_TRIM_HYPERDLL == 1)
-    SPIM_HYPER_SET_AUTO_TRIM_DLL(spim, SPIM_OP_ENABLE);
-
     SPIM_HYPER_SET_INTERNAL_RWDS(spim, SPIM_OP_ENABLE);
+    SPIM_HYPER_SET_AUTO_TRIM_DLL(spim, SPIM_OP_ENABLE);
 #endif
 
-    /* User asserts this control register to 0x1,
-       the DLL circuit begins searching for lock with DLL reference clock. */
+    // Start DLL output valid countdown
     SPIM_HYPER_ENABLE_DLLOVRST(spim, SPIM_HYPER_OP_ENABLE);
 
-    i32TimeoutCount = SPIM_HYPER_TIMEOUT;
+    // Wait DLLOVRST auto-clear
+    i32TimeoutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
-    /* Polling the DLL status register DLLCKON to 0x1,
-       and the value 0x1 indicates that clock divider circuit inside DLL is enabled. */
-    while (SPIM_HYPER_GET_DLLOVRST(spim) == SPIM_HYPER_OP_ENABLE)
-    {
-        if (--i32TimeoutCount <= 0)
-        {
-            return SPIM_HYPER_ERR_TIMEOUT;
-        }
-    }
+    while (SPIM_HYPER_GET_DLLOVRST(spim))
+        if (--i32TimeoutCount <= 0) return SPIM_HYPER_ERR_TIMEOUT;
 
-    i32TimeoutCount = SPIM_HYPER_TIMEOUT;
+    // Wait clock divider ON
+    i32TimeoutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
-    /* Polling the DLL status register DLLCKON to 0x1,
-       and the value 0x1 indicates that clock divider circuit inside DLL is enabled. */
-    while (SPIM_HYPER_GET_DLLCLKON(spim) != SPIM_HYPER_OP_ENABLE)
-    {
-        if (--i32TimeoutCount <= 0)
-        {
-            return SPIM_HYPER_ERR_TIMEOUT;
-        }
-    }
+    while (SPIM_HYPER_GET_DLLCLKON(spim) != SPIM_OP_ENABLE)
+        if (--i32TimeoutCount <= 0) return SPIM_HYPER_ERR_TIMEOUT;
 
-    i32TimeoutCount = SPIM_HYPER_TIMEOUT;
+    // Wait DLL LOCK
+    i32TimeoutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
-    /* Polling the DLL status register DLLLOCK to 0x1,
-       and the value 0x1 indicates that DLL circuit is in lock state */
-    while (SPIM_HYPER_GET_DLLLOCK(spim) != SPIM_HYPER_OP_ENABLE)
-    {
-        if (--i32TimeoutCount <= 0)
-        {
-            return SPIM_HYPER_ERR_TIMEOUT;
-        }
-    }
+    while (SPIM_HYPER_GET_DLLLOCK(spim) != SPIM_OP_ENABLE)
+        if (--i32TimeoutCount <= 0) return SPIM_HYPER_ERR_TIMEOUT;
 
-    i32TimeoutCount = SPIM_HYPER_TIMEOUT;
+    // Wait DLL output READY
+    i32TimeoutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
-    /* Polling the DLL status register DLLREADY to 0x1,
-       and the value 0x1 indicates that output of DLL circuit is ready. */
-    while (SPIM_HYPER_GET_DLLREADY(spim) != SPIM_HYPER_OP_ENABLE)
-    {
-        if (--i32TimeoutCount <= 0)
-        {
-            return SPIM_HYPER_ERR_TIMEOUT;
-        }
-    }
+    while (SPIM_HYPER_GET_DLLREADY(spim) != SPIM_OP_ENABLE)
+        if (--i32TimeoutCount <= 0) return SPIM_HYPER_ERR_TIMEOUT;
 
 #if (SPIM_HYPER_TRIM_HYPERDLL == 1)
-    i32TimeoutCount = SPIM_TIMEOUT;
+    // Wait auto-trim ready
+    i32TimeoutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
-    /* Polling the DLL status register DLLREADY to 0x1,
-    and the value 0x1 indicates that output of DLL circuit is ready. */
     while (SPIM_HYPER_GET_DLLATRDY(spim) != SPIM_OP_ENABLE)
-    {
-        if (--i32TimeoutCount <= 0)
-        {
-            return SPIM_ERR_TIMEOUT;
-        }
-    }
+        if (--i32TimeoutCount <= 0) return SPIM_HYPER_ERR_TIMEOUT;
 
-    /* wait for auto trim setting */
-    for (i32TimeoutCount = 0; i32TimeoutCount < 0x200000; i32TimeoutCount++)
-    {
+    u32DelayCycleCount = (uint32_t)(u32BusClkHz / 1000) * 3;  // 3ms = 3 * (Hz / 1000)
+
+    for (i32TimeoutCount = 0; i32TimeoutCount < (int32_t)u32DelayCycleCount; i32TimeoutCount++)
         __NOP();
-    }
 
     SPIM_HYPER_DISABLE_SYSDLL0ATCTL0_TRIMUPDOFF();
-
     SPIM_HYPER_SET_INTERNAL_RWDS(spim, SPIM_HYPER_OP_DISABLE);
 #endif
 
-    if (u32RegLockLevel)
-    {
-        /* Lock protected registers */
-        SYS_LockReg();
-    }
+    if (u32RegLockLevel) SYS_LockReg();
 
     return SPIM_HYPER_OK;
 }
 
 /**
   * @brief      Set SPIM DLL delay number.
-  * @param      spim   SPIM port handler
-  * @param      u32DelayNum   The delay number of SPIM DLL.
-  * @retval     SPIM_HYPER_OK          SPIM operation OK.
-  *             SPIM_HYPER_ERR_TIMEOUT SPIM operation abort due to timeout error.
+  * @param      spim    Pointer to the SPIM peripheral.
+  * @param      u32DelayNum The delay number of SPIM DLL.
+  * @return     SPIM_HYPER_OK          Operation completed successfully.
+  *             SPIM_HYPER_ERR_TIMEOUT Operation aborted due to timeout error.
   * @details    This function is used to set SPIM DLL delay number.
   *             The delay number is used to adjust the sampling edge of input clock
   *             to SPIM.
   */
 int32_t SPIM_HYPER_SetDLLDelayNum(SPIM_T *spim, uint32_t u32DelayNum)
 {
-    volatile int i32Timeout = SPIM_HYPER_TIMEOUT;
+    volatile int i32TimeoutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
     if (SPIM_HYPER_GET_DLLOLDO(spim) != SPIM_HYPER_OP_ENABLE)
     {
-        SPIM_HYPER_INIT_DLL(spim);
+        if (SPIM_HYPER_INIT_DLL(spim) != SPIM_HYPER_OK)
+        {
+            return SPIM_HYPER_ERR_FAIL;
+        }
     }
 
-    /* Set this valid delay number to control register DLL_DNUM. */
-    SPIM_HYPER_SET_DLLDLY_NUM(spim, u32DelayNum);
-
-    i32Timeout = SPIM_HYPER_TIMEOUT;
+    i32TimeoutCount = (int32_t)SPIM_HYPER_TIMEOUT;
 
     /* Polling DLL status register DLL_REF to 0
        to know the updating flow of DLL delay step number is finish or not. */
     while (SPIM_HYPER_GET_DLLREF(spim) != SPIM_HYPER_OP_DISABLE)
-    {
-        if (--i32Timeout <= 0)
-        {
-            return SPIM_HYPER_ERR_TIMEOUT;
-        }
-    }
+        if (--i32TimeoutCount <= 0) return SPIM_HYPER_ERR_TIMEOUT;
+
+    /* Set this valid delay number to control register DLL_DNUM. */
+    SPIM_HYPER_SET_DLLDLY_NUM(spim, u32DelayNum);
+
+    i32TimeoutCount = (int32_t)SPIM_HYPER_TIMEOUT;
+
+    /* Polling DLL status register DLL_REF to 0
+       to know the updating flow of DLL delay step number is finish or not. */
+    while (SPIM_HYPER_GET_DLLREF(spim) != SPIM_HYPER_OP_DISABLE)
+        if (--i32TimeoutCount <= 0) return SPIM_HYPER_ERR_TIMEOUT;
 
     return SPIM_HYPER_OK;
 }


### PR DESCRIPTION
This updates HyperRAM driver to BSP V3.01.003. The major change is to disable default MLDO adjustment. It can fix failure of 2nd or 3rd `west flash` and fit NuMaker-X-M55M1 board.