### PR TITLE
hal: nuvoton: m55m1: update LPPDMA driver to V3.01.003

### DIFF
--- a/m55m1x/StdDriver/inc/lppdma.h
+++ b/m55m1x/StdDriver/inc/lppdma.h
@@ -92,8 +92,8 @@ extern "C"
 /*---------------------------------------------------------------------------------------------------------*/
 /*  Interrupt Type Constant Definitions                                                                    */
 /*---------------------------------------------------------------------------------------------------------*/
-#define LPPDMA_INT_TRANS_DONE 0x00000000UL            /*!<Transfer Done Interrupt  \hideinitializer */
-#define LPPDMA_INT_TEMPTY     0x00000001UL            /*!<Table Empty Interrupt  \hideinitializer */
+#define LPPDMA_INT_TRANS_DONE 0x00000001UL            /*!<Transfer Done Interrupt  \hideinitializer */
+#define LPPDMA_INT_TEMPTY     0x00000002UL            /*!<Table Empty Interrupt  \hideinitializer */
 
 
 /** @} end of group LPPDMA_EXPORTED_CONSTANTS */

--- a/m55m1x/StdDriver/src/lppdma.c
+++ b/m55m1x/StdDriver/src/lppdma.c
@@ -9,7 +9,7 @@
 
 #include "NuMicro.h"
 
-static uint8_t u32ChSelect[LPPDMA_CH_MAX];
+static uint32_t u32ChSelect[LPPDMA_CH_MAX];
 
 /** @addtogroup Standard_Driver Standard Driver
   @{
@@ -221,18 +221,14 @@ void LPPDMA_Trigger(LPPDMA_T *lppdma, uint32_t u32Ch)
  */
 void LPPDMA_EnableInt(LPPDMA_T *lppdma, uint32_t u32Ch, uint32_t u32Mask)
 {
-    switch (u32Mask)
+    if (u32Mask & LPPDMA_INT_TRANS_DONE)
     {
-        case LPPDMA_INT_TRANS_DONE:
-            lppdma->INTEN |= (1ul << u32Ch);
-            break;
+        (lppdma)->INTEN |= (1UL << u32Ch);
+    }
 
-        case LPPDMA_INT_TEMPTY:
-            lppdma->LPDSCT[u32Ch].CTL &= ~LPPDMA_DSCT_CTL_TBINTDIS_Msk;
-            break;
-
-        default:
-            break;
+    if (u32Mask & LPPDMA_INT_TEMPTY)
+    {
+        (lppdma)->LPDSCT[u32Ch].CTL &= ~LPPDMA_DSCT_CTL_TBINTDIS_Msk;
     }
 }
 
@@ -249,18 +245,14 @@ void LPPDMA_EnableInt(LPPDMA_T *lppdma, uint32_t u32Ch, uint32_t u32Mask)
  */
 void LPPDMA_DisableInt(LPPDMA_T *lppdma, uint32_t u32Ch, uint32_t u32Mask)
 {
-    switch (u32Mask)
+    if (u32Mask & LPPDMA_INT_TRANS_DONE)
     {
-        case LPPDMA_INT_TRANS_DONE:
-            lppdma->INTEN &= ~(1ul << u32Ch);
-            break;
+        (lppdma)->INTEN &= ~(1UL << u32Ch);
+    }
 
-        case LPPDMA_INT_TEMPTY:
-            lppdma->LPDSCT[u32Ch].CTL |= LPPDMA_DSCT_CTL_TBINTDIS_Msk;
-            break;
-
-        default:
-            break;
+    if (u32Mask & LPPDMA_INT_TEMPTY)
+    {
+        (lppdma)->LPDSCT[u32Ch].CTL |= LPPDMA_DSCT_CTL_TBINTDIS_Msk;
     }
 }
 


### PR DESCRIPTION
This updates LPPDMA driver to BSP V3.01.003. One significant fix is to change values of macros `LPPDMA_INT_TRANS_DONE` and` LPPDMA_INT_TEMPTY` so that they can be OR'ed together to pass to `LPPDMA_EnableInt` or` LPPDMA_DisableInt`.