### PR TITLE
hal: nuvoton: m55m1: removed SCB->VTOR setting in SystemInit

### DIFF
--- a/m55m1x/Devices/M55M1/Source/system_M55M1.c
+++ b/m55m1x/Devices/M55M1/Source/system_M55M1.c
@@ -334,7 +334,8 @@ void SystemInit(void)
     SCB_CleanDCache();
 #endif
 
-    SCB->VTOR = 0x100000;
+    /* Set SCB->VTOR should be in zephyr/arch/arm/core/cortex_m/scb.c, especially build with BOOTLOADER_MCUBOOT */
+    //SCB->VTOR = 0x100000;
 
 #if 0
 #if defined (__VTOR_PRESENT) && (__VTOR_PRESENT == 1U)


### PR DESCRIPTION
This PR is to remove SCB->VTOR setting in SystemInit of hal.
