### PR TITLE
hal: nuvoton: m3351: Add support of FMC_Erase_Bank

### DIFF
--- a/m335x/StdDriver/inc/fmc.h
+++ b/m335x/StdDriver/inc/fmc.h
@@ -699,6 +699,7 @@ extern void     FMC_Open(void);
 extern void     FMC_Close(void);
 extern int32_t  FMC_ConfigXOM(uint32_t u32XomNum, uint32_t u32XomBase, uint8_t u8XomPage);
 extern int32_t  FMC_Erase(uint32_t u32PageAddr);
+extern int32_t  FMC_Erase_Bank(uint32_t u32BankAddr);
 extern int32_t  FMC_EraseXOM(uint32_t u32XomNum);
 extern int32_t  FMC_GetXOMState(uint32_t u32XomNum);
 extern uint32_t FMC_Read(uint32_t u32Addr);

--- a/m335x/StdDriver/src/fmc.c
+++ b/m335x/StdDriver/src/fmc.c
@@ -126,6 +126,57 @@ int32_t FMC_Erase(uint32_t u32PageAddr)
 }
 
 /**
+  * @brief Execute FMC_ISPCMD_PAGE_ERASE command to erase a flash bank.
+  * @param[in]  u32BankAddr Base address of the flash bank to be erased.
+  * @return ISP page erase success or not.
+  * @retval   0  Success
+  * @retval   -1  Erase failed
+  *
+  * @note     Global error code g_FMC_i32ErrCode
+  *           -1  Erase failed or erase time-out
+  */
+int32_t FMC_Erase_Bank(uint32_t u32BankAddr)
+{
+    int32_t i32RetCode = FMC_OK;
+    int32_t i32TimeOutCnt;
+    int page_nums = (FMC_BANK_SIZE / FMC_FLASH_PAGE_SIZE);
+    uint32_t u32PageAddr = u32BankAddr;
+
+    g_FMC_i32ErrCode = FMC_OK;
+
+    FMC->ISPCMD  = FMC_ISPCMD_PAGE_ERASE;
+    FMC->ISPTRG  = FMC_ISPTRG_ISPGO_Msk;
+
+    while (page_nums)
+    {
+        FMC->ISPADDR = u32PageAddr;
+        i32TimeOutCnt = FMC_TIMEOUT_ERASE;
+
+        while (FMC->ISPTRG & FMC_ISPTRG_ISPGO_Msk)
+        {
+            if (i32TimeOutCnt-- <= 0)
+            {
+                i32RetCode = FMC_ERR_TIMEOUT;
+                g_FMC_i32ErrCode = i32RetCode;
+                break;
+            }
+        }
+
+        if (FMC->ISPCTL & FMC_ISPCTL_ISPFF_Msk)
+        {
+            FMC->ISPCTL |= FMC_ISPCTL_ISPFF_Msk;
+            i32RetCode = FMC_ERR_FAIL;
+            g_FMC_i32ErrCode = i32RetCode;
+	    break;
+        }
+	page_nums--;
+	u32PageAddr += FMC_FLASH_PAGE_SIZE;
+    }
+    
+    return i32RetCode;
+}
+
+/**
   * @brief  Execute Erase XOM Region
   *
   * @param[in]  u32XomNum  The XOM number (0~1).


### PR DESCRIPTION
This PR is to add support of FMC_Erase_Bank API in fmc.c for M3351.